### PR TITLE
Added retire event. Moved insn_disas, insn_pc, and insn_val assignmen…

### DIFF
--- a/rtl/riscv_tracer.sv
+++ b/rtl/riscv_tracer.sv
@@ -104,6 +104,8 @@ module riscv_tracer (
   integer      cycles;
   logic [ 5:0] rd, rs1, rs2, rs3, rs4;
 
+  event        retire;
+  
   typedef struct {
     logic [ 5:0] addr;
     logic [31:0] value;
@@ -791,6 +793,13 @@ module riscv_tracer (
     end
   end
 
+  // these signals are for simulator visibility. Don't try to do the nicer way
+  // of making instr_trace_t visible to inspect it with your simulator. Some
+  // choke for some unknown performance reasons.
+  string insn_disas;
+  logic [31:0] insn_pc;
+  logic [31:0] insn_val;
+
   // virtual EX/WB pipeline
   initial
   begin
@@ -810,16 +819,12 @@ module riscv_tracer (
       end while (!wb_valid);
 
       trace.printInstrTrace();
+      insn_disas = trace.str;
+      insn_pc    = trace.pc;
+      insn_val   = trace.instr;
+      -> retire;
     end
   end
-
-
-  // these signals are for simulator visibility. Don't try to do the nicer way
-  // of making instr_trace_t visible to inspect it with your simulator. Some
-  // choke for some unknown performance reasons.
-  string insn_disas;
-  logic [31:0] insn_pc;
-  logic [31:0] insn_val;
 
   // log execution
   always @(negedge clk)
@@ -1017,11 +1022,6 @@ module riscv_tracer (
         {25'b?, OPCODE_VECOP}:      trace.printVecInstr();
         default:           trace.printMnemonic("INVALID");
       endcase // unique case (instr)
-
-      // visibility for simulator
-      insn_disas = trace.str;
-      insn_pc    = trace.pc;
-      insn_val   = trace.instr;
 
       instr_ex.put(trace);
     end


### PR DESCRIPTION
This pull request is to address https://github.com/pulp-platform/riscv/issues/218
1) Added a retire event.
2) Moved assignment to insn_disas, insn_pc, and insn_val assignment to after retire event trigger so these variables change only when an instruction is retired.  This enables a testbench to wait on the retire event and collect the results of the retired instructions.  If you want to keep the assignment of these 3 variables as-is I can create separate signals.