### PR TITLE
:art: Cleanup manifest file #247

### DIFF
--- a/cv32e40p_manifest.flist
+++ b/cv32e40p_manifest.flist
@@ -1,19 +1,19 @@
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Copyright 2020 OpenHW Group
-// 
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Manifest for the CV32E40P RTL model.
@@ -33,7 +33,11 @@ ${DESIGN_RTL_DIR}/include/riscv_defines.sv
 ${DESIGN_RTL_DIR}/include/riscv_tracer_defines.sv
 ${DESIGN_RTL_DIR}/riscv_if_stage.sv
 ${DESIGN_RTL_DIR}/riscv_tracer.sv
+`ifdef SYNTHESIS
 ${DESIGN_RTL_DIR}/cv32e40p_sim_clock_gating.sv
+`else
+${DESIGN_TECH_DIR}/cv32e40p_clock_gating.sv
+`endif
 ${DESIGN_RTL_DIR}/riscv_cs_registers.sv
 ${DESIGN_RTL_DIR}/riscv_register_file.sv
 ${DESIGN_RTL_DIR}/riscv_load_store_unit.sv
@@ -42,8 +46,6 @@ ${DESIGN_RTL_DIR}/riscv_decoder.sv
 ${DESIGN_RTL_DIR}/riscv_compressed_decoder.sv
 ${DESIGN_RTL_DIR}/riscv_fetch_fifo.sv
 ${DESIGN_RTL_DIR}/riscv_prefetch_buffer.sv
-${DESIGN_RTL_DIR}/riscv_prefetch_L0_buffer.sv
-${DESIGN_RTL_DIR}/riscv_L0_buffer.sv
 ${DESIGN_RTL_DIR}/riscv_hwloop_regs.sv
 ${DESIGN_RTL_DIR}/riscv_hwloop_controller.sv
 ${DESIGN_RTL_DIR}/riscv_mult.sv


### PR DESCRIPTION
-  Adding `ifdef SYNTHESIS` preprocessor directives to not synthesize the simulation clock gating cell.

- Remove not used prefetcher buffer for 128b instruction bus