### PR TITLE
Disable inference of FP registers/latches when `Zfinx` is enabled

### DIFF
--- a/rtl/riscv_register_file.sv
+++ b/rtl/riscv_register_file.sv
@@ -161,7 +161,7 @@ module riscv_register_file
 
     end
 
-    if (FPU == 1) begin
+    if (FPU == 1 && Zfinx == 0) begin
       // Floating point registers
       for(l = 0; l < NUM_FP_WORDS; l++) begin
         always_ff @(posedge clk, negedge rst_n)

--- a/rtl/riscv_register_file_latch.sv
+++ b/rtl/riscv_register_file_latch.sv
@@ -209,7 +209,7 @@ module riscv_register_file
           end
      end
 
-   if (FPU == 1) begin
+   if (FPU == 1 && Zfinx == 0) begin
    // Floating point registers
    always_latch
       begin : latch_wdata_fp


### PR DESCRIPTION
This patch removes the [unused `mem_fp` registers with the `Zfinx` extension enabled](https://github.com/openhwgroup/cv32e40p/issues/288) and fixes #288.