### PR TITLE
Propagated is_decoding signal to the APU_DISPATCHER to mask read and write dependency

### DIFF
--- a/rtl/riscv_apu_disp.sv
+++ b/rtl/riscv_apu_disp.sv
@@ -45,6 +45,7 @@ module riscv_apu_disp (
   output logic                          stall_o,
 
   // dependency checks
+  input  logic                          is_decoding_i,
   input  logic [2:0][5:0]               read_regs_i,
   input  logic [2:0]                    read_regs_valid_i,
   output logic                          read_dep_o,
@@ -189,8 +190,8 @@ module riscv_apu_disp (
   assign write_dep_inflight = |write_deps_inflight & valid_inflight & !returned_inflight;
   assign write_dep_waiting  = |write_deps_waiting  & valid_waiting  & !returned_waiting;
 
-  assign read_dep_o         = read_dep_req  | read_dep_inflight  | read_dep_waiting;
-  assign write_dep_o        = write_dep_req | write_dep_inflight | write_dep_waiting;
+  assign read_dep_o         = (read_dep_req  | read_dep_inflight  | read_dep_waiting)  & is_decoding_i;
+  assign write_dep_o        = (write_dep_req | write_dep_inflight | write_dep_waiting) & is_decoding_i;
 
   //
   // Stall signals

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -894,6 +894,7 @@ module riscv_core
     .regfile_alu_wdata_fw_o     ( regfile_alu_wdata_fw         ),
 
     // stall control
+    .is_decoding_i              ( is_decoding                  ),
     .lsu_ready_ex_i             ( lsu_ready_ex                 ),
     .lsu_err_i                  ( data_err_pmp                 ),
 

--- a/rtl/riscv_ex_stage.sv
+++ b/rtl/riscv_ex_stage.sv
@@ -157,8 +157,9 @@ module riscv_ex_stage
   output logic        branch_decision_o,
 
   // Stall Control
-  input  logic        lsu_ready_ex_i, // EX part of LSU is done
-  input  logic        lsu_err_i,
+  input logic         is_decoding_i, // Used to mask data Dependency inside the APU dispatcher in case of an istruction non valid
+  input logic         lsu_ready_ex_i, // EX part of LSU is done
+  input logic         lsu_err_i,
 
   output logic        ex_ready_o, // EX stage ready for new data
   output logic        ex_valid_o, // EX stage gets new data
@@ -361,6 +362,7 @@ module riscv_ex_stage
          .active_o           ( apu_active                     ),
          .stall_o            ( apu_stall                      ),
 
+         .is_decoding_i      ( is_decoding_i                  ),
          .read_regs_i        ( apu_read_regs_i                ),
          .read_regs_valid_i  ( apu_read_regs_valid_i          ),
          .read_dep_o         ( apu_read_dep_o                 ),


### PR DESCRIPTION
### FIX

Propagate the `is_decoding` signal from the `controller` to the `apu_dispatcher` to mask read and write dependency. There was a case that, when the `fetch_valid` signal in the `if_stage` was 0, the instruction in the `decode_stage` would not advance but that same instruction would go to the `ex_stage`. This would cause a false read dependency with the currently executed instruction and the instruction it self (since the instruction in the `id_stage` and `ex_stage` was the same). Masking it with the `is_decoding` signal fixes this performance bug avoiding an extra stall when this happened.