### PR TITLE
Fix#302

### DIFF
--- a/rtl/include/riscv_defines.sv
+++ b/rtl/include/riscv_defines.sv
@@ -187,6 +187,15 @@ parameter VEC_MODE32 = 2'b00;
 parameter VEC_MODE16 = 2'b10;
 parameter VEC_MODE8  = 2'b11;
 
+
+  // FSM state encoding
+  typedef enum  logic [4:0] { RESET, BOOT_SET, SLEEP, WAIT_SLEEP, FIRST_FETCH,
+                      DECODE,
+                      IRQ_TAKEN_ID, IRQ_TAKEN_IF, IRQ_FLUSH, IRQ_FLUSH_ELW, ELW_EXE,
+                      FLUSH_EX, FLUSH_WB, XRET_JUMP,
+                      DBG_TAKEN_ID, DBG_TAKEN_IF, DBG_FLUSH, DBG_WAIT_BRANCH } ctrl_state_e;
+
+
 /////////////////////////////////////////////////////////
 //    ____ ____    ____            _     _             //
 //   / ___/ ___|  |  _ \ ___  __ _(_)___| |_ ___ _ __  //

--- a/rtl/riscv_controller.sv
+++ b/rtl/riscv_controller.sv
@@ -188,11 +188,7 @@ module riscv_controller
 );
 
   // FSM state encoding
-  enum  logic [4:0] { RESET, BOOT_SET, SLEEP, WAIT_SLEEP, FIRST_FETCH,
-                      DECODE,
-                      IRQ_TAKEN_ID, IRQ_TAKEN_IF, IRQ_FLUSH, IRQ_FLUSH_ELW, ELW_EXE,
-                      FLUSH_EX, FLUSH_WB, XRET_JUMP,
-                      DBG_TAKEN_ID, DBG_TAKEN_IF, DBG_FLUSH, DBG_WAIT_BRANCH } ctrl_fsm_cs, ctrl_fsm_ns;
+  ctrl_state_e ctrl_fsm_cs, ctrl_fsm_ns;
 
   logic jump_done, jump_done_q, jump_in_dec, branch_in_id;
   logic boot_done, boot_done_q;

--- a/rtl/riscv_controller.sv
+++ b/rtl/riscv_controller.sv
@@ -475,9 +475,6 @@ module riscv_controller
 
                   halt_if_o         = 1'b1;
                   halt_id_o         = 1'b1;
-                  csr_save_id_o     = 1'b1;
-                  csr_save_cause_o  = 1'b1;
-                  csr_cause_o       = EXC_CAUSE_ILLEGAL_INSN;
                   ctrl_fsm_ns       = FLUSH_EX;
                   illegal_insn_n    = 1'b1;
                 end else begin
@@ -512,11 +509,7 @@ module riscv_controller
 
                       else begin
                         // otherwise just a normal ebreak exception
-                        csr_save_id_o     = 1'b1;
-                        csr_save_cause_o  = 1'b1;
-
                         ctrl_fsm_ns = FLUSH_EX;
-                        csr_cause_o = EXC_CAUSE_BREAKPOINT;
                       end
 
                     end
@@ -528,9 +521,6 @@ module riscv_controller
                     ecall_insn_i: begin
                       halt_if_o     = 1'b1;
                       halt_id_o     = 1'b1;
-                      csr_save_id_o     = 1'b1;
-                      csr_save_cause_o  = 1'b1;
-                      csr_cause_o   = current_priv_lvl_i == PRIV_LVL_U ? EXC_CAUSE_ECALL_UMODE : EXC_CAUSE_ECALL_MMODE;
                       ctrl_fsm_ns   = FLUSH_EX;
                     end
                     fencei_insn_i: begin
@@ -617,9 +607,31 @@ module riscv_controller
             //so the illegal was never executed
             illegal_insn_n    = 1'b0;
         end  //data erro
-        else if (ex_valid_i)
+        else if (ex_valid_i) begin
           //check done to prevent data harzard in the CSR registers
           ctrl_fsm_ns = FLUSH_WB;
+
+          if(illegal_insn_q) begin
+            csr_save_id_o     = 1'b1;
+            csr_save_cause_o  = 1'b1;
+            csr_cause_o       = EXC_CAUSE_ILLEGAL_INSN;
+          end else begin
+            unique case (1'b1)
+              ebrk_insn_i: begin
+                csr_save_id_o     = 1'b1;
+                csr_save_cause_o  = 1'b1;
+                csr_cause_o       = EXC_CAUSE_BREAKPOINT;
+              end
+              ecall_insn_i: begin
+                csr_save_id_o     = 1'b1;
+                csr_save_cause_o  = 1'b1;
+                csr_cause_o       = current_priv_lvl_i == PRIV_LVL_U ? EXC_CAUSE_ECALL_UMODE : EXC_CAUSE_ECALL_MMODE;
+              end
+              default:;
+            endcase // unique case (1'b1)
+          end
+
+        end
       end
 
 

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -1168,6 +1168,7 @@ module riscv_core
 
     .pc             ( id_stage_i.pc_id_i                   ),
     .instr          ( id_stage_i.instr                     ),
+    .controller_state_i ( id_stage_i.controller_i.ctrl_fsm_cs ),
     .compressed     ( id_stage_i.is_compressed_i           ),
     .id_valid       ( id_stage_i.id_valid_o                ),
     .is_decoding    ( id_stage_i.is_decoding_o             ),

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -123,8 +123,8 @@ module riscv_core
   localparam SHARED_INT_DIV      =  0;
   localparam SHARED_FP_DIVSQRT   =  0;
 
-  // Unused signals related to above unused parameters 
-  // Left in code (with their original _i, _o postfixes) for future design extensions; 
+  // Unused signals related to above unused parameters
+  // Left in code (with their original _i, _o postfixes) for future design extensions;
   // these used to be former inputs/outputs of RI5CY
 
   logic [5:0]                     data_atop_o;  // atomic operation, only active if parameter `A_EXTENSION != 0`
@@ -1197,6 +1197,7 @@ module riscv_core
     .ex_data_gnt    ( data_gnt_i                           ),
     .ex_data_we     ( data_we_o                            ),
     .ex_data_wdata  ( data_wdata_o                         ),
+    .data_misaligned ( data_misaligned                     ),
 
     .wb_bypass      ( ex_stage_i.branch_in_ex_i            ),
 


### PR DESCRIPTION
This PR addes fixes for retire event of misaligned memory accesses and xret and ecall functions

Issues: 

https://github.com/openhwgroup/cv32e40p/issues/302
https://github.com/openhwgroup/cv32e40p/issues/256