### PR TITLE
riscv_cs_register: Fix clearing of PC registers

### DIFF
--- a/rtl/riscv_cs_registers.sv
+++ b/rtl/riscv_cs_registers.sv
@@ -1350,7 +1350,7 @@ end //PULP_SECURE
         CSR_OP_NONE:   ;
         CSR_OP_WRITE:  PCCR_n[0] = csr_wdata_i;
         CSR_OP_SET:    PCCR_n[0] = csr_wdata_i | PCCR_q[0];
-        CSR_OP_CLEAR:  PCCR_n[0] = csr_wdata_i & ~(PCCR_q[0]);
+        CSR_OP_CLEAR:  PCCR_n[0] = ~(csr_wdata_i) & PCCR_q[0];
       endcase
     end
   end
@@ -1371,7 +1371,7 @@ end //PULP_SECURE
           CSR_OP_NONE:   ;
           CSR_OP_WRITE:  PCCR_n[i] = csr_wdata_i;
           CSR_OP_SET:    PCCR_n[i] = csr_wdata_i | PCCR_q[i];
-          CSR_OP_CLEAR:  PCCR_n[i] = csr_wdata_i & ~(PCCR_q[i]);
+          CSR_OP_CLEAR:  PCCR_n[i] = ~(csr_wdata_i) & PCCR_q[i];
         endcase
       end
     end
@@ -1389,7 +1389,7 @@ end //PULP_SECURE
         CSR_OP_NONE:   ;
         CSR_OP_WRITE:  PCMR_n = csr_wdata_i[1:0];
         CSR_OP_SET:    PCMR_n = csr_wdata_i[1:0] | PCMR_q;
-        CSR_OP_CLEAR:  PCMR_n = csr_wdata_i[1:0] & ~(PCMR_q);
+        CSR_OP_CLEAR:  PCMR_n = ~(csr_wdata_i[1:0]) & PCMR_q;
       endcase
     end
 
@@ -1398,7 +1398,7 @@ end //PULP_SECURE
         CSR_OP_NONE:   ;
         CSR_OP_WRITE:  PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0];
         CSR_OP_SET:    PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0] | PCER_q;
-        CSR_OP_CLEAR:  PCER_n = csr_wdata_i[N_PERF_COUNTERS-1:0] & ~(PCER_q);
+        CSR_OP_CLEAR:  PCER_n = ~(csr_wdata_i[N_PERF_COUNTERS-1:0]) & PCER_q;
       endcase
     end
   end


### PR DESCRIPTION
According to the RISC-V specification (Section 9.1 of the Unprivileged ISA), the CSR Read and Clear instruction (CSRRC) treats the value in register `rs1` as a bit mask that specifies bit positions to be cleared in the CSR.  Any bit that is high in `rs1` will cause the corresponding bit to be cleared in the CSR.

This commit changes the code for `PCCR`, `PCMR`, and `PCER` accordingly.