### PR TITLE
Cleaned up undriven signals and inferred latch (trap_base_addr)

### DIFF
--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -128,8 +128,8 @@ module riscv_core
   // these used to be former inputs/outputs of RI5CY
 
   logic [5:0]                     data_atop_o;  // atomic operation, only active if parameter `A_EXTENSION != 0`
-  logic [N_EXT_PERF_COUNTERS-1:0] ext_perf_counters_i = 'b0;
-  logic                           irq_sec_i = 1'b0;
+  logic [N_EXT_PERF_COUNTERS-1:0] ext_perf_counters_i;
+  logic                           irq_sec_i;
   logic                           sec_lvl_o;
 
   localparam N_HWLP      = 2;
@@ -154,8 +154,6 @@ module riscv_core
   logic [2:0]        exc_pc_mux_id; // Mux selector for exception PC
   logic [5:0]        exc_cause;
   logic [1:0]        trap_addr_mux;
-  logic              lsu_load_err;
-  logic              lsu_store_err;
 
   // ID performance counter signals
   logic        is_decoding;
@@ -203,7 +201,7 @@ module riscv_core
   logic [31:0] mult_dot_op_b_ex;
   logic [31:0] mult_dot_op_c_ex;
   logic [ 1:0] mult_dot_signed_ex;
-  logic        mult_is_clpx_ex_o;
+  logic        mult_is_clpx_ex;
   logic [ 1:0] mult_clpx_shift_ex;
   logic        mult_clpx_img_ex;
 
@@ -213,7 +211,6 @@ module riscv_core
   logic [C_FFLAG-1:0]         fflags;
   logic [C_FFLAG-1:0]         fflags_csr;
   logic                       fflags_we;
-
 
   // APU
   logic                        apu_en_ex;
@@ -296,11 +293,6 @@ module riscv_core
   logic        m_irq_enable, u_irq_enable;
   logic        csr_irq_sec;
   logic [31:0] mepc, uepc, depc;
-  logic        irq_software;
-  logic        irq_timer;
-  logic        irq_external;
-  logic [14:0] irq_fast;
-  logic        irq_nmi;
 
   logic        csr_save_cause;
   logic        csr_save_if;
@@ -330,7 +322,6 @@ module riscv_core
   logic               [2:0] csr_hwlp_we;
   logic              [31:0] csr_hwlp_data;
 
-
   // Performance Counters
   logic        perf_imiss;
   logic        perf_jump;
@@ -341,14 +332,12 @@ module riscv_core
   //core busy signals
   logic        core_ctrl_firstfetch, core_busy_int, core_busy_q;
 
-
   //pmp signals
   logic  [N_PMP_ENTRIES-1:0] [31:0] pmp_addr;
   logic  [N_PMP_ENTRIES-1:0] [7:0]  pmp_cfg;
 
   logic                             data_req_pmp;
   logic [31:0]                      data_addr_pmp;
-  logic                             data_we_pmp;
   logic                             data_gnt_pmp;
   logic                             data_err_pmp;
   logic                             data_err_ack;
@@ -364,6 +353,12 @@ module riscv_core
   //Simchecker signal
   logic is_interrupt;
   assign is_interrupt = (pc_mux_id == PC_EXCEPTION) && (exc_pc_mux_id == EXC_PC_IRQ);
+
+  // N_EXT_PERF_COUNTERS == 0
+  assign ext_perf_counters_i = 'b0;
+
+  // PULP_SECURE == 0
+  assign irq_sec_i = 1'b0;
 
   // APU master signals
    generate

--- a/rtl/riscv_cs_registers.sv
+++ b/rtl/riscv_cs_registers.sv
@@ -288,7 +288,7 @@ module riscv_cs_registers
   logic [31:0] menipx;
 
   logic is_irq;
-  PrivLvl_t priv_lvl_n, priv_lvl_q, priv_lvl_reg_q;
+  PrivLvl_t priv_lvl_n, priv_lvl_q;
   Pmp_t pmp_reg_q, pmp_reg_n;
   //clock gating for pmp regs
   logic [MAX_N_PMP_ENTRIES-1:0] pmpaddr_we;
@@ -844,6 +844,7 @@ end else begin //PULP_SECURE == 0
     fprec_n                  = fprec_q;
     mscratch_n               = mscratch_q;
     mepc_n                   = mepc_q;
+    uepc_n                   = 'b0;             // Not used if PULP_SECURE == 0
     depc_n                   = depc_q;
     dcsr_n                   = dcsr_q;
     dscratch0_n              = dscratch0_q;
@@ -851,13 +852,16 @@ end else begin //PULP_SECURE == 0
 
     mstatus_n                = mstatus_q;
     mcause_n                 = mcause_q;
+    ucause_n                 = '0;              // Not used if PULP_SECURE == 0
     hwlp_we_o                = '0;
     hwlp_regid_o             = '0;
     exception_pc             = pc_id_i;
     priv_lvl_n               = priv_lvl_q;
     mtvec_n                  = mtvec_q;
-    pmp_reg_n.pmpaddr        = pmp_reg_q.pmpaddr;
-    pmp_reg_n.pmpcfg_packed  = pmp_reg_q.pmpcfg_packed;
+    utvec_n                  = '0;              // Not used if PULP_SECURE == 0
+    pmp_reg_n.pmpaddr        = '0;              // Not used if PULP_SECURE == 0
+    pmp_reg_n.pmpcfg_packed  = '0;              // Not used if PULP_SECURE == 0
+    pmp_reg_n.pmpcfg         = '0;              // Not used if PULP_SECURE == 0
     pmpaddr_we               = '0;
     pmpcfg_we                = '0;
 
@@ -1175,7 +1179,7 @@ end //PULP_SECURE
 
   end
   else begin
-
+        assign pmp_reg_q    = '0;
         assign uepc_q       = '0;
         assign ucause_q     = '0;
         assign utvec_q      = '0;
@@ -1190,11 +1194,9 @@ end //PULP_SECURE
   begin
     if (rst_n == 1'b0)
     begin
-      if (FPU == 1) begin
-        frm_q          <= '0;
-        fflags_q       <= '0;
-        fprec_q        <= '0;
-      end
+      frm_q      <= '0;
+      fflags_q   <= '0;
+      fprec_q    <= '0;
       mstatus_q  <= '{
               uie:  1'b0,
               mie:  1'b0,
@@ -1224,6 +1226,10 @@ end //PULP_SECURE
         frm_q      <= frm_n;
         fflags_q   <= fflags_n;
         fprec_q    <= fprec_n;
+      end else begin
+        frm_q      <= 'b0;
+        fflags_q   <= 'b0;
+        fprec_q    <= 'b0;
       end
       if (PULP_SECURE == 1) begin
         mstatus_q      <= mstatus_n ;

--- a/rtl/riscv_ex_stage.sv
+++ b/rtl/riscv_ex_stage.sv
@@ -178,8 +178,6 @@ module riscv_ex_stage
   logic           alu_ready;
   logic           mult_ready;
   logic           fpu_ready;
-  logic           fpu_valid;
-
 
   // APU signals
   logic           apu_valid;
@@ -501,6 +499,10 @@ module riscv_ex_stage
          assign apu_master_operands_o[1] = '0;
          assign apu_master_operands_o[2] = '0;
          assign apu_master_op_o          = '0;
+         assign apu_req                  = 1'b0;
+         assign apu_gnt                  = 1'b0;
+         assign apu_ready                = 1'b0;
+         assign apu_result               = 32'b0;
          assign apu_valid       = 1'b0;
          assign apu_waddr       = 6'b0;
          assign apu_stall       = 1'b0;

--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -1015,8 +1015,8 @@ module riscv_id_stage
      // BIST ports
      .CSN_T       ( 1'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
      .WEN_T       ( 1'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
-     .A_T         (  'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
-     .D_T         (  'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
+     .A_T         ( 6'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
+     .D_T         (32'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
      .Q_T         (                     )
   );
 

--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -937,6 +937,11 @@ module riscv_id_stage
       for (genvar i=0; i<APU_NARGS_CPU; i++) begin : apu_tie_off
         assign apu_operands[i]       = '0;
       end
+
+      assign apu_read_regs           = '0;
+      assign apu_read_regs_valid     = '0;
+      assign apu_write_regs          = '0;
+      assign apu_write_regs_valid    = '0;
       assign apu_waddr               = '0;
       assign apu_flags               = '0;
       assign apu_write_regs_o        = '0;
@@ -1008,10 +1013,10 @@ module riscv_id_stage
      .BIST        ( 1'b0                ), // PLEASE CONNECT ME;
 
      // BIST ports
-     .CSN_T       (                     ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
-     .WEN_T       (                     ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
-     .A_T         (                     ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
-     .D_T         (                     ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
+     .CSN_T       ( 1'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
+     .WEN_T       ( 1'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
+     .A_T         (  'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
+     .D_T         (  'b0                ), // PLEASE CONNECT ME; Synthesis will remove me if unconnected
      .Q_T         (                     )
   );
 

--- a/rtl/riscv_if_stage.sv
+++ b/rtl/riscv_if_stage.sv
@@ -131,6 +131,7 @@ module riscv_if_stage
   always_comb
   begin : EXC_PC_MUX
     exc_pc = '0;
+    trap_base_addr = '0;
 
     unique case (trap_addr_mux_i)
       TRAP_MACHINE:  trap_base_addr = m_trap_base_addr_i;

--- a/rtl/riscv_if_stage.sv
+++ b/rtl/riscv_if_stage.sv
@@ -130,21 +130,18 @@ module riscv_if_stage
   // exception PC selection mux
   always_comb
   begin : EXC_PC_MUX
-    exc_pc = '0;
-    trap_base_addr = '0;
-
     unique case (trap_addr_mux_i)
       TRAP_MACHINE:  trap_base_addr = m_trap_base_addr_i;
       TRAP_USER:     trap_base_addr = u_trap_base_addr_i;
       TRAP_MACHINEX: trap_base_addr = m_trap_base_addrx_i;
-      default:;
+      default:       trap_base_addr = m_trap_base_addr_i;
     endcase
 
     unique case (exc_pc_mux_i)
       EXC_PC_EXCEPTION:                        exc_pc = { trap_base_addr, 8'h0 }; //1.10 all the exceptions go to base address
       EXC_PC_IRQ:                              exc_pc = { trap_base_addr, 1'b0, exc_vec_pc_mux_i[4:0], 2'b0 }; // interrupts are vectored
       EXC_PC_DBD:                              exc_pc = { DM_HALTADDRESS       };
-      default:;
+      default:                                 exc_pc = { trap_base_addr, 8'h0 };
     endcase
   end
 

--- a/rtl/riscv_register_file.sv
+++ b/rtl/riscv_register_file.sv
@@ -174,6 +174,8 @@ module riscv_register_file
             mem_fp[l] <= wdata_a_i;
         end
       end
+    end else begin
+      assign mem_fp = 'b0;
     end
 
   endgenerate


### PR DESCRIPTION
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>

Added 0 assignments to many signals that became undriven due to our chosen configuration. Also prevented latch generation on trap_base_addr (in IF stage) by adding default 0 assignment.