### PR TITLE
Parameterize hardware loop in the decoder

### DIFF
--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -37,6 +37,7 @@ import riscv_defines::*;
 
 module riscv_core
 #(
+  parameter PULP_HWLP           =  0,
   parameter PULP_CLUSTER        =  0,
   parameter FPU                 =  0,
   parameter PULP_ZFINX          =  0,
@@ -556,6 +557,7 @@ module riscv_core
   /////////////////////////////////////////////////
   riscv_id_stage
   #(
+    .PULP_HWLP                    ( PULP_HWLP            ),
     .N_HWLP                       ( N_HWLP               ),
     .PULP_SECURE                  ( PULP_SECURE          ),
     .A_EXTENSION                  ( A_EXTENSION          ),

--- a/rtl/riscv_decoder.sv
+++ b/rtl/riscv_decoder.sv
@@ -31,6 +31,7 @@ import riscv_defines::*;
 
 module riscv_decoder
 #(
+  parameter PULP_HWLP         = 0,
   parameter A_EXTENSION       = 0,
   parameter FPU               = 0,
   parameter FP_DIVSQRT        = 0,
@@ -2424,56 +2425,61 @@ module riscv_decoder
       ///////////////////////////////////////////////
 
       OPCODE_HWLOOP: begin
-        hwloop_target_mux_sel_o = 1'b0;
+        if(PULP_HWLP) begin : HWLOOP_FEATURE_ENABLED
+          hwloop_target_mux_sel_o = 1'b0;
 
-        unique case (instr_rdata_i[14:12])
-          3'b000: begin
-            // lp.starti: set start address to PC + I-type immediate
-            hwloop_we[0]           = 1'b1;
-            hwloop_start_mux_sel_o = 1'b0;
-          end
+          unique case (instr_rdata_i[14:12])
+            3'b000: begin
+              // lp.starti: set start address to PC + I-type immediate
+              hwloop_we[0]           = 1'b1;
+              hwloop_start_mux_sel_o = 1'b0;
+            end
 
-          3'b001: begin
-            // lp.endi: set end address to PC + I-type immediate
-            hwloop_we[1]         = 1'b1;
-          end
+            3'b001: begin
+              // lp.endi: set end address to PC + I-type immediate
+              hwloop_we[1]         = 1'b1;
+            end
 
-          3'b010: begin
-            // lp.count: initialize counter from rs1
-            hwloop_we[2]         = 1'b1;
-            hwloop_cnt_mux_sel_o = 1'b1;
-            rega_used_o          = 1'b1;
-          end
+            3'b010: begin
+              // lp.count: initialize counter from rs1
+              hwloop_we[2]         = 1'b1;
+              hwloop_cnt_mux_sel_o = 1'b1;
+              rega_used_o          = 1'b1;
+            end
 
-          3'b011: begin
-            // lp.counti: initialize counter from I-type immediate
-            hwloop_we[2]         = 1'b1;
-            hwloop_cnt_mux_sel_o = 1'b0;
-          end
+            3'b011: begin
+              // lp.counti: initialize counter from I-type immediate
+              hwloop_we[2]         = 1'b1;
+              hwloop_cnt_mux_sel_o = 1'b0;
+            end
 
-          3'b100: begin
-            // lp.setup: initialize counter from rs1, set start address to
-            // next instruction and end address to PC + I-type immediate
-            hwloop_we              = 3'b111;
-            hwloop_start_mux_sel_o = 1'b1;
-            hwloop_cnt_mux_sel_o   = 1'b1;
-            rega_used_o            = 1'b1;
-          end
+            3'b100: begin
+              // lp.setup: initialize counter from rs1, set start address to
+              // next instruction and end address to PC + I-type immediate
+              hwloop_we              = 3'b111;
+              hwloop_start_mux_sel_o = 1'b1;
+              hwloop_cnt_mux_sel_o   = 1'b1;
+              rega_used_o            = 1'b1;
+            end
 
-          3'b101: begin
-            // lp.setupi: initialize counter from immediate, set start address to
-            // next instruction and end address to PC + I-type immediate
-            hwloop_we               = 3'b111;
-            hwloop_target_mux_sel_o = 1'b1;
-            hwloop_start_mux_sel_o  = 1'b1;
-            hwloop_cnt_mux_sel_o    = 1'b0;
-          end
+            3'b101: begin
+              // lp.setupi: initialize counter from immediate, set start address to
+              // next instruction and end address to PC + I-type immediate
+              hwloop_we               = 3'b111;
+              hwloop_target_mux_sel_o = 1'b1;
+              hwloop_start_mux_sel_o  = 1'b1;
+              hwloop_cnt_mux_sel_o    = 1'b0;
+            end
 
-          default: begin
-            illegal_insn_o = 1'b1;
-          end
-        endcase
-      end
+            default: begin
+              illegal_insn_o = 1'b1;
+            end
+          endcase // case (instr_rdata_i[14:12])
+
+        end else begin // block: HWLOOP_FEATURE_ENABLED
+          illegal_insn_o = 1'b1;
+        end
+      end // case: OPCODE_HWLOOP
 
       default: begin
         illegal_insn_o = 1'b1;

--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -39,6 +39,7 @@ import apu_core_package::*;
 
 module riscv_id_stage
 #(
+  parameter PULP_HWLP         =  0,
   parameter N_HWLP            =  2,
   parameter N_HWLP_BITS       =  $clog2(N_HWLP),
   parameter PULP_SECURE       =  0,
@@ -1029,6 +1030,7 @@ module riscv_id_stage
 
   riscv_decoder
     #(
+      .PULP_HWLP           ( PULP_HWLP            ),
       .A_EXTENSION         ( A_EXTENSION          ),
       .FPU                 ( FPU                  ),
       .FP_DIVSQRT          ( FP_DIVSQRT           ),


### PR DESCRIPTION
This pull request works in conjunction with #322 pull request to address issue #277 :

The hardware loop is not removed but is parameterized out. The default is no hardware loop.
