### PR TITLE
#330 add debug trigger

### DIFF
--- a/rtl/include/riscv_defines.sv
+++ b/rtl/include/riscv_defines.sv
@@ -256,6 +256,14 @@ typedef enum logic[11:0] {
   CSR_PMPADDR14 = 12'h3BE,
   CSR_PMPADDR15 = 12'h3BF,
 
+  // Trigger
+  CSR_TSELECT   = 12'h7A0,
+  CSR_TDATA1    = 12'h7A1,
+  CSR_TDATA2    = 12'h7A2,
+  CSR_TDATA3    = 12'h7A3,
+  CSR_MCONTEXT  = 12'h7A8,
+  CSR_SCONTEXT  = 12'h7AA,
+
   // Debug/trace
   CSR_DCSR      = 12'h7b0,
   CSR_DPC       = 12'h7b1,
@@ -449,6 +457,7 @@ parameter TRAP_USER         = 2'b01;
 parameter TRAP_MACHINEX     = 2'b10;
 
 // Debug Cause
+parameter DBG_CAUSE_NONE       = 3'h0;
 parameter DBG_CAUSE_EBREAK     = 3'h1;
 parameter DBG_CAUSE_TRIGGER    = 3'h2;
 parameter DBG_CAUSE_HALTREQ    = 3'h3;
@@ -466,6 +475,13 @@ parameter DBG_SETS_EBRK   = 1;
 parameter DBG_SETS_SSTE   = 0;
 
 parameter DBG_CAUSE_HALT   = 6'h1F;
+
+// Constants for the dcsr.xdebugver fields
+typedef enum logic[3:0] {
+   XDEBUGVER_NO     = 4'd0, // no external debug support
+   XDEBUGVER_STD    = 4'd4, // external debug according to RISC-V debug spec
+   XDEBUGVER_NONSTD = 4'd15 // debug not conforming to RISC-V debug spec
+} x_debug_ver_e;
 
 
 /////////////////////////////////////
@@ -561,7 +577,6 @@ parameter PCCR_LAST    =  12'h79F;             //NON standard PCCR last includes
 //Custom Hart and Priveledge
 parameter UHARTID     = 12'h014; //NON standard read/write (Machine CSRs) - User Hart ID
 parameter PRIVLV      = 12'hC10; //NON standard read/write (Machine CSRs) - Privilege Level
-
 //Custom Floating Point
 parameter FPREC       = 12'h006; //NON standard read/write (Machine CSRs) - Floating Point
 

--- a/rtl/riscv_controller.sv
+++ b/rtl/riscv_controller.sv
@@ -125,7 +125,7 @@ module riscv_controller
   input  logic         debug_single_step_i,
   input  logic         debug_ebreakm_i,
   input  logic         debug_ebreaku_i,
-
+  input  logic         debug_trig_i,
 
   output logic        csr_save_if_o,
   output logic        csr_save_id_o,

--- a/rtl/riscv_controller.sv
+++ b/rtl/riscv_controller.sv
@@ -125,7 +125,7 @@ module riscv_controller
   input  logic         debug_single_step_i,
   input  logic         debug_ebreakm_i,
   input  logic         debug_ebreaku_i,
-  input  logic         debug_trig_i,
+  input  logic         trigger_match_i,
 
   output logic        csr_save_if_o,
   output logic        csr_save_id_o,
@@ -343,7 +343,7 @@ module riscv_controller
 
         // normal execution flow
         // in debug mode or single step mode we leave immediately (wfi=nop)
-        if (irq_pending_i || (debug_req_i || debug_mode_q || debug_single_step_i)) begin
+        if (irq_pending_i || (debug_req_i || debug_mode_q || debug_single_step_i || trigger_match_i)) begin
           ctrl_fsm_ns  = FIRST_FETCH;
         end
 
@@ -368,7 +368,7 @@ module riscv_controller
           halt_id_o   = 1'b1;
         end
 
-        if (debug_req_i & (~debug_mode_q))
+        if ((debug_req_i || trigger_match_i) & (~debug_mode_q))
         begin
           ctrl_fsm_ns = DBG_TAKEN_IF;
           halt_if_o   = 1'b1;
@@ -453,7 +453,7 @@ module riscv_controller
               end
 
 
-              debug_req_i & (~debug_mode_q):
+              (debug_req_i || trigger_match_i) & (~debug_mode_q):
               begin
                 //Serving the debug
                 halt_if_o     = 1'b1;
@@ -693,7 +693,7 @@ module riscv_controller
         //If an interrupt occurs, we replay the ELW
         //No needs to check irq_int_req_i since in the EX stage there is only the elw, no CSR pendings
         if(id_ready_i)
-          ctrl_fsm_ns = (debug_req_i & ~debug_mode_q) ? DBG_FLUSH : IRQ_FLUSH_ELW;
+          ctrl_fsm_ns = ((debug_req_i || trigger_match_i) & ~debug_mode_q) ? DBG_FLUSH : IRQ_FLUSH_ELW;
           // if from the ELW EXE we go to IRQ_FLUSH_ELW, it is assumed that if there was an IRQ req together with the grant and IE was valid, then
           // there must be no hazard due to xIE
         else
@@ -924,7 +924,7 @@ module riscv_controller
         pc_set_o          = 1'b1;
         pc_mux_o          = PC_EXCEPTION;
         exc_pc_mux_o      = EXC_PC_DBD;
-        if ((debug_req_i && (~debug_mode_q)) ||
+        if (((debug_req_i || trigger_match_i) && (~debug_mode_q)) ||
             (ebrk_insn_i && ebrk_force_debug_mode && (~debug_mode_q))) begin
             csr_save_cause_o = 1'b1;
             csr_save_id_o    = 1'b1;
@@ -933,6 +933,8 @@ module riscv_controller
                 debug_cause_o = DBG_CAUSE_HALTREQ;
             if (ebrk_insn_i)
                 debug_cause_o = DBG_CAUSE_EBREAK;
+            if (trigger_match_i)
+                debug_cause_o = DBG_CAUSE_TRIGGER;
         end
         ctrl_fsm_ns  = DECODE;
         debug_mode_n = 1'b1;
@@ -952,6 +954,8 @@ module riscv_controller
             debug_cause_o = DBG_CAUSE_HALTREQ;
         if (ebrk_insn_i)
             debug_cause_o = DBG_CAUSE_EBREAK;
+        if (trigger_match_i)
+          debug_cause_o   = DBG_CAUSE_TRIGGER;
         csr_save_if_o   = 1'b1;
         ctrl_fsm_ns     = DECODE;
         debug_mode_n    = 1'b1;

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -40,6 +40,7 @@ module riscv_core
   parameter PULP_CLUSTER        =  0,
   parameter FPU                 =  0,
   parameter PULP_ZFINX          =  0,
+  parameter DEBUG_TRIGGER_EN    =  1,
   parameter DM_HALTADDRESS      = 32'h1A110800
 )
 (
@@ -319,6 +320,7 @@ module riscv_core
   logic        debug_single_step;
   logic        debug_ebreakm;
   logic        debug_ebreaku;
+  logic        trigger_match;
 
   // Hardware loop controller signals
   logic [N_HWLP-1:0] [31:0] hwlp_start;
@@ -573,7 +575,8 @@ module riscv_core
     .APU_NARGS_CPU                ( APU_NARGS_CPU        ),
     .APU_WOP_CPU                  ( APU_WOP_CPU          ),
     .APU_NDSFLAGS_CPU             ( APU_NDSFLAGS_CPU     ),
-    .APU_NUSFLAGS_CPU             ( APU_NUSFLAGS_CPU     )
+    .APU_NUSFLAGS_CPU             ( APU_NUSFLAGS_CPU     ),
+    .DEBUG_TRIGGER_EN             ( DEBUG_TRIGGER_EN     )
   )
   id_stage_i
   (
@@ -747,6 +750,7 @@ module riscv_core
     .debug_single_step_i          ( debug_single_step    ),
     .debug_ebreakm_i              ( debug_ebreakm        ),
     .debug_ebreaku_i              ( debug_ebreaku        ),
+    .trigger_match_i              ( trigger_match        ),
 
     // Forward Signals
     .regfile_waddr_wb_i           ( regfile_waddr_fw_wb_o),  // Write address ex-wb pipeline
@@ -972,13 +976,14 @@ module riscv_core
 
   riscv_cs_registers
   #(
-    .N_EXT_CNT       ( N_EXT_PERF_COUNTERS   ),
-    .A_EXTENSION     ( A_EXTENSION           ),
-    .FPU             ( FPU                   ),
-    .APU             ( APU                   ),
-    .PULP_SECURE     ( PULP_SECURE           ),
-    .USE_PMP         ( USE_PMP               ),
-    .N_PMP_ENTRIES   ( N_PMP_ENTRIES         )
+    .N_EXT_CNT        ( N_EXT_PERF_COUNTERS   ),
+    .A_EXTENSION      ( A_EXTENSION           ),
+    .FPU              ( FPU                   ),
+    .APU              ( APU                   ),
+    .PULP_SECURE      ( PULP_SECURE           ),
+    .USE_PMP          ( USE_PMP               ),
+    .N_PMP_ENTRIES    ( N_PMP_ENTRIES         ),
+    .DEBUG_TRIGGER_EN ( DEBUG_TRIGGER_EN      )
   )
   cs_registers_i
   (
@@ -1028,6 +1033,7 @@ module riscv_core
     .debug_single_step_o     ( debug_single_step  ),
     .debug_ebreakm_o         ( debug_ebreakm      ),
     .debug_ebreaku_o         ( debug_ebreaku      ),
+    .trigger_match_o         ( trigger_match      ),
 
     .priv_lvl_o              ( current_priv_lvl   ),
 

--- a/rtl/riscv_core.sv
+++ b/rtl/riscv_core.sv
@@ -40,7 +40,6 @@ module riscv_core
   parameter PULP_CLUSTER        =  0,
   parameter FPU                 =  0,
   parameter PULP_ZFINX          =  0,
-  parameter DEBUG_TRIGGER_EN    =  1,
   parameter DM_HALTADDRESS      = 32'h1A110800
 )
 (
@@ -123,6 +122,7 @@ module riscv_core
   localparam SHARED_INT_MULT     =  0;
   localparam SHARED_INT_DIV      =  0;
   localparam SHARED_FP_DIVSQRT   =  0;
+  localparam DEBUG_TRIGGER_EN    =  1;
 
   // Unused signals related to above unused parameters
   // Left in code (with their original _i, _o postfixes) for future design extensions;

--- a/rtl/riscv_cs_registers.sv
+++ b/rtl/riscv_cs_registers.sv
@@ -45,7 +45,8 @@ module riscv_cs_registers
   parameter FPU           = 0,
   parameter PULP_SECURE   = 0,
   parameter USE_PMP       = 0,
-  parameter N_PMP_ENTRIES = 16
+  parameter N_PMP_ENTRIES = 16,
+  parameter DEBUG_TRIGGER_EN = 1
 )
 (
   // Clock and Reset
@@ -220,7 +221,6 @@ module riscv_cs_registers
     logic mprv;
   } Status_t;
 
-
   typedef struct packed{
       logic [31:28] xdebugver;
       logic [27:16] zero2;
@@ -264,6 +264,11 @@ module riscv_cs_registers
   // Interrupt control signals
   logic [31:0] mepc_q, mepc_n;
   logic [31:0] uepc_q, uepc_n;
+  // Trigger
+  logic [31:0] tmatch_control_rdata;
+  logic [31:0] tmatch_value_rdata;
+  logic        trigger_match_o;
+  // Debug
   Dcsr_t       dcsr_q, dcsr_n;
   logic [31:0] depc_q, depc_n;
   logic [31:0] dscratch0_q, dscratch0_n;
@@ -422,6 +427,16 @@ if(PULP_SECURE==1) begin
       // mhartid: unique hardware thread id
       CSR_MHARTID: csr_rdata_int = {21'b0, cluster_id_i[5:0], 1'b0, core_id_i[3:0]};
 
+      CSR_TSELECT,
+        CSR_TDATA3,
+        CSR_MCONTEXT,
+        CSR_SCONTEXT:
+               csr_rdata_int = 'b0; // Always read 0
+      CSR_TDATA1:
+               csr_rdata_int = tmatch_control_rdata;
+      CSR_TDATA2:
+               csr_rdata_int = tmatch_value_rdata;
+
       CSR_DCSR:
                csr_rdata_int = dcsr_q;//
       CSR_DPC:
@@ -533,6 +548,16 @@ end else begin //PULP_SECURE == 0
       CSR_MIPX: csr_rdata_int = mipx;
       // mhartid: unique hardware thread id
       CSR_MHARTID: csr_rdata_int = {21'b0, cluster_id_i[5:0], 1'b0, core_id_i[3:0]};
+
+      CSR_TSELECT,
+        CSR_TDATA3,
+        CSR_MCONTEXT,
+        CSR_SCONTEXT:
+               csr_rdata_int = 'b0; // Always read 0
+      CSR_TDATA1:
+               csr_rdata_int = tmatch_control_rdata;
+      CSR_TDATA2:
+               csr_rdata_int = tmatch_value_rdata;
 
       CSR_DCSR:
                csr_rdata_int = dcsr_q;//
@@ -648,6 +673,7 @@ if(PULP_SECURE==1) begin
       // mcause
       CSR_MCAUSE: if (csr_we_int) mcause_n = {csr_wdata_int[31], csr_wdata_int[5:0]};
 
+      // Debug
       CSR_DCSR:
                if (csr_we_int)
                begin
@@ -1215,8 +1241,12 @@ end //PULP_SECURE
       mcause_q    <= '0;
 
       depc_q      <= '0;
-      dcsr_q      <= '0;
-      dcsr_q.prv  <= PRIV_LVL_M;
+      dcsr_q         <= '{
+          xdebugver: XDEBUGVER_STD,
+          cause:     DBG_CAUSE_NONE, // 3'h0
+          prv:       PRIV_LVL_M,
+          default:   '0
+      };
       dscratch0_q <= '0;
       dscratch1_q <= '0;
       mscratch_q  <= '0;
@@ -1247,7 +1277,6 @@ end //PULP_SECURE
       end
       mepc_q     <= mepc_n    ;
       mcause_q   <= mcause_n  ;
-
       depc_q     <= depc_n    ;
       dcsr_q     <= dcsr_n;
       dscratch0_q<= dscratch0_n;
@@ -1258,8 +1287,82 @@ end //PULP_SECURE
       mtvec_q    <= mtvec_n;
       mtvecx_q   <= mtvecx_n;
     end
+  end 
+ ////////////////////////////////////////////////////////////////////////
+ //  ____       _                   _____     _                        //
+ // |  _ \  ___| |__  _   _  __ _  |_   _| __(_) __ _  __ _  ___ _ __  //
+ // | | | |/ _ \ '_ \| | | |/ _` |   | || '__| |/ _` |/ _` |/ _ \ '__| //
+ // | |_| |  __/ |_) | |_| | (_| |   | || |  | | (_| | (_| |  __/ |    //
+ // |____/ \___|_.__/ \__,_|\__, |   |_||_|  |_|\__, |\__, |\___|_|    //
+ //                         |___/               |___/ |___/            // 
+ ////////////////////////////////////////////////////////////////////////
+  
+  if (DEBUG_TRIGGER_EN) begin : gen_trigger_regs
+    // Register values
+    logic        tmatch_control_exec_n, tmatch_control_exec_q;
+    logic [31:0] tmatch_value_n       , tmatch_value_q;
+    // Write enables
+    logic tmatch_control_we;
+    logic tmatch_value_we;
+
+    // Write select
+    assign tmatch_control_we = csr_we_int & debug_mode_i & (csr_addr_i == CSR_TDATA1);
+    assign tmatch_value_we   = csr_we_int & debug_mode_i & (csr_addr_i == CSR_TDATA2);
+
+    // tmatch_control is enabled when the execute bit is set
+    assign tmatch_control_exec_n = tmatch_control_we ? csr_wdata_int[2] :
+                                                       tmatch_control_exec_q;
+    // tmatch_value has its own clock gate
+    assign tmatch_value_n   = csr_wdata_int[31:0];
+
+    // Registers
+    always_ff @(posedge clk or negedge rst_n) begin
+      if (!rst_n) begin
+        tmatch_control_exec_q <= 'b0;
+        tmatch_value_q        <= 'b0;
+      end else begin
+        tmatch_control_exec_q <= tmatch_control_exec_n;
+        tmatch_value_q        <= tmatch_value_n;
+     end
+    end
+
+    // Assign read data
+    // TDATA0 - only support simple address matching
+    assign tmatch_control_rdata = 
+               {
+                4'h2,                  // type    : address/data match
+                1'b1,                  // dmode   : access from D mode only
+                6'h00,                 // maskmax : exact match only
+                1'b0,                  // hit     : not supported
+                1'b0,                  // select  : address match only
+                1'b0,                  // timing  : match before execution
+                2'b00,                 // sizelo  : match any access
+                4'h1,                  // action  : enter debug mode
+                1'b0,                  // chain   : not supported
+                4'h0,                  // match   : simple match
+                1'b1,                  // m       : match in m-mode
+                1'b0,                  // 0       : zero
+                1'b0,                  // s       : not supported
+                PULP_SECURE==1,        // u       : match in u-mode
+                tmatch_control_exec_q, // execute : match instruction address
+                1'b0,                  // store   : not supported
+                1'b0};                 // load    : not supported
+
+    // TDATA1 - address match value only
+    assign tmatch_value_rdata = tmatch_value_q;
+
+    // Breakpoint matching
+    // We match against the next address, as the breakpoint must be taken before execution
+    assign trigger_match_o = tmatch_control_exec_q &
+                              (pc_id_i[31:0] == tmatch_value_q[31:0]);
+
+  end else begin : gen_no_trigger_regs
+    assign tmatch_control_rdata = 'b0;
+    assign tmatch_value_rdata   = 'b0;
+    assign trigger_match_o      = 'b0;
   end
 
+  
   /////////////////////////////////////////////////////////////////
   //   ____            __     ____                  _            //
   // |  _ \ ___ _ __ / _|   / ___|___  _   _ _ __ | |_ ___ _ __  //

--- a/rtl/riscv_cs_registers.sv
+++ b/rtl/riscv_cs_registers.sv
@@ -104,6 +104,7 @@ module riscv_cs_registers
   output logic            debug_single_step_o,
   output logic            debug_ebreakm_o,
   output logic            debug_ebreaku_o,
+  output logic            trigger_match_o,
 
 
   output logic  [N_PMP_ENTRIES-1:0] [31:0] pmp_addr_o,
@@ -267,7 +268,6 @@ module riscv_cs_registers
   // Trigger
   logic [31:0] tmatch_control_rdata;
   logic [31:0] tmatch_value_rdata;
-  logic        trigger_match_o;
   // Debug
   Dcsr_t       dcsr_q, dcsr_n;
   logic [31:0] depc_q, depc_n;
@@ -1287,16 +1287,16 @@ end //PULP_SECURE
       mtvec_q    <= mtvec_n;
       mtvecx_q   <= mtvecx_n;
     end
-  end 
+  end
  ////////////////////////////////////////////////////////////////////////
  //  ____       _                   _____     _                        //
  // |  _ \  ___| |__  _   _  __ _  |_   _| __(_) __ _  __ _  ___ _ __  //
  // | | | |/ _ \ '_ \| | | |/ _` |   | || '__| |/ _` |/ _` |/ _ \ '__| //
  // | |_| |  __/ |_) | |_| | (_| |   | || |  | | (_| | (_| |  __/ |    //
  // |____/ \___|_.__/ \__,_|\__, |   |_||_|  |_|\__, |\__, |\___|_|    //
- //                         |___/               |___/ |___/            // 
+ //                         |___/               |___/ |___/            //
  ////////////////////////////////////////////////////////////////////////
-  
+
   if (DEBUG_TRIGGER_EN) begin : gen_trigger_regs
     // Register values
     logic        tmatch_control_exec_n, tmatch_control_exec_q;
@@ -1309,11 +1309,6 @@ end //PULP_SECURE
     assign tmatch_control_we = csr_we_int & debug_mode_i & (csr_addr_i == CSR_TDATA1);
     assign tmatch_value_we   = csr_we_int & debug_mode_i & (csr_addr_i == CSR_TDATA2);
 
-    // tmatch_control is enabled when the execute bit is set
-    assign tmatch_control_exec_n = tmatch_control_we ? csr_wdata_int[2] :
-                                                       tmatch_control_exec_q;
-    // tmatch_value has its own clock gate
-    assign tmatch_value_n   = csr_wdata_int[31:0];
 
     // Registers
     always_ff @(posedge clk or negedge rst_n) begin
@@ -1321,14 +1316,16 @@ end //PULP_SECURE
         tmatch_control_exec_q <= 'b0;
         tmatch_value_q        <= 'b0;
       end else begin
-        tmatch_control_exec_q <= tmatch_control_exec_n;
-        tmatch_value_q        <= tmatch_value_n;
+        if(tmatch_control_we)
+          tmatch_control_exec_q <= csr_wdata_int[2];
+        if(tmatch_value_we)
+          tmatch_value_q        <= csr_wdata_int[31:0];
      end
     end
 
     // Assign read data
     // TDATA0 - only support simple address matching
-    assign tmatch_control_rdata = 
+    assign tmatch_control_rdata =
                {
                 4'h2,                  // type    : address/data match
                 1'b1,                  // dmode   : access from D mode only
@@ -1362,7 +1359,6 @@ end //PULP_SECURE
     assign trigger_match_o      = 'b0;
   end
 
-  
   /////////////////////////////////////////////////////////////////
   //   ____            __     ____                  _            //
   // |  _ \ ___ _ __ / _|   / ___|___  _   _ _ __ | |_ ___ _ __  //

--- a/rtl/riscv_decoder.sv
+++ b/rtl/riscv_decoder.sv
@@ -43,7 +43,8 @@ module riscv_decoder
   parameter SHARED_INT_DIV    = 0,
   parameter SHARED_FP_DIVSQRT = 0,
   parameter WAPUTYPE          = 0,
-  parameter APU_WOP_CPU       = 6
+  parameter APU_WOP_CPU       = 6,
+  parameter DEBUG_TRIGGER_EN  = 1
 )
 (
   // singals running to/from controller
@@ -2444,6 +2445,16 @@ module riscv_decoder
               CSR_DSCRATCH0,
               CSR_DSCRATCH1 :
                 if(!debug_mode_i) csr_illegal = 1'b1;
+
+            // Debug Trigger register access
+            CSR_TSELECT     ,
+              CSR_TDATA1    ,
+              CSR_TDATA2    ,
+              CSR_TDATA3    ,
+              CSR_MCONTEXT  ,
+              CSR_SCONTEXT  :
+                if(!debug_mode_i || DEBUG_TRIGGER_EN != 1)
+                  csr_illegal = 1'b1;
 
             // Hardware Loop register access
             HWLoop0_START,

--- a/rtl/riscv_id_stage.sv
+++ b/rtl/riscv_id_stage.sv
@@ -57,7 +57,8 @@ module riscv_id_stage
   parameter APU_NARGS_CPU     =  3,
   parameter APU_WOP_CPU       =  6,
   parameter APU_NDSFLAGS_CPU  = 15,
-  parameter APU_NUSFLAGS_CPU  =  5
+  parameter APU_NUSFLAGS_CPU  =  5,
+  parameter DEBUG_TRIGGER_EN  =  1
 )
 (
     input  logic        clk,
@@ -231,6 +232,7 @@ module riscv_id_stage
     input  logic        debug_single_step_i,
     input  logic        debug_ebreakm_i,
     input  logic        debug_ebreaku_i,
+    input  logic        trigger_match_i,
 
     // Forward Signals
     input  logic [5:0]  regfile_waddr_wb_i,
@@ -1041,7 +1043,8 @@ module riscv_id_stage
       .SHARED_INT_DIV      ( SHARED_INT_DIV       ),
       .SHARED_FP_DIVSQRT   ( SHARED_FP_DIVSQRT    ),
       .WAPUTYPE            ( WAPUTYPE             ),
-      .APU_WOP_CPU         ( APU_WOP_CPU          )
+      .APU_WOP_CPU         ( APU_WOP_CPU          ),
+      .DEBUG_TRIGGER_EN    ( DEBUG_TRIGGER_EN     )
       )
   decoder_i
   (
@@ -1267,6 +1270,7 @@ module riscv_id_stage
     .debug_single_step_i            ( debug_single_step_i    ),
     .debug_ebreakm_i                ( debug_ebreakm_i        ),
     .debug_ebreaku_i                ( debug_ebreaku_i        ),
+    .trigger_match_i                ( trigger_match_i        ),
 
     // CSR Controller Signals
     .csr_save_cause_o               ( csr_save_cause_o       ),


### PR DESCRIPTION
Add debug trigger logic resolving issue #330.

Trigger CSRs added:
  CSR_TSELECT   = 12'h7A0,
  CSR_TDATA1    = 12'h7A1,
  CSR_TDATA2    = 12'h7A2,
  CSR_TDATA3    = 12'h7A3,
  CSR_MCONTEXT  = 12'h7A8,
  CSR_SCONTEXT  = 12'h7AA,
Only TDATA1 and TDATA2 have RW fields, the rest are default 0

Trigger CSRs not accessible unless in debug_mode.

Added DEBUG_TRIGGER_EN parameter.


