### PR TITLE
tb: Remove inline ecall

### DIFF
--- a/tb/core/custom/hello_world.c
+++ b/tb/core/custom/hello_world.c
@@ -44,8 +44,6 @@ int main(int argc, char *argv[])
 #ifdef RANDOM_MEM_STALL
     activate_random_stall();
 #endif
-    /* inline assembly */
-    asm volatile("ecall");
     /* write something to stdout */
     printf("hello world!\n");
     return EXIT_SUCCESS;

--- a/tb/core/custom_fp/main.c
+++ b/tb/core/custom_fp/main.c
@@ -57,8 +57,6 @@ int main(int argc, char *argv[])
   float tmpA, tmpB, tmpC;
   int error = 0;
 
-  asm volatile("ecall");
-
   tmpA = 1.14f;
   tmpB = 0.75f;
   tmpC = 12.1f;


### PR DESCRIPTION
These actually serve no purpose. They were used for local testing and
accidentally commited and propagated.