### PR TITLE
Added sleep pin indicating when clk_i is allowed to be gated externally

### DIFF
--- a/tb/core/riscv_wrapper.sv
+++ b/tb/core/riscv_wrapper.sv
@@ -119,6 +119,7 @@ module riscv_wrapper
          .debug_req_i            ( debug_req_i           ),
 
          .fetch_enable_i         ( fetch_enable_i        ),
+         .core_sleep_o           ( core_sleep_o          ),
          .core_busy_o            ( core_busy_o           ),
 
          .fregfile_disable_i     ( 1'b0                  ));

--- a/tb/dm/tb_test_env.sv
+++ b/tb/dm/tb_test_env.sv
@@ -161,6 +161,7 @@ module tb_test_env
         .debug_req_i            ( dm_debug_req[CORE_MHARTID] ),
 
         .fetch_enable_i         ( fetch_enable_i        ),
+        .core_sleep_o           ( core_sleep_o          ),
         .core_busy_o            ( core_busy_o           ),
 
         .fregfile_disable_i     ( 1'b0                  ));

--- a/tb/dm/tb_top_verilator.sv
+++ b/tb/dm/tb_top_verilator.sv
@@ -160,6 +160,7 @@ module tb_top_verilator #(
         .debug_req_i            ( dm_debug_req[CORE_MHARTID] ),
 
         .fetch_enable_i         ( fetch_enable_i        ),
+        .core_sleep_o           ( core_sleep_o          ),
         .core_busy_o            ( core_busy_o           ),
 
         .fregfile_disable_i     ( 1'b0                  ));

--- a/tb/tb_riscv/tb_riscv_core.sv
+++ b/tb/tb_riscv/tb_riscv_core.sv
@@ -108,6 +108,7 @@ module tb_riscv_core
 
   // CPU Control Signals
   input  logic        fetch_enable_i,
+  output logic        core_sleep_o
   output logic        core_busy_o
 );
 
@@ -209,6 +210,7 @@ logic [4:0]                    irq_core_resp_id_int;
     .debug_req_i                    ( debug_req_int           ),
 
     .fetch_enable_i                 ( fetch_enable_i          ),
+    .core_sleep_o                   ( core_sleep_o            ),
     .core_busy_o                    ( core_busy_o             ),
 
     .fregfile_disable_i             ( fregfile_disable_i      )

--- a/tb/verilator-model/top.sv
+++ b/tb/verilator-model/top.sv
@@ -38,6 +38,7 @@ module top
 
  // CPU Control Signals
  input logic            fetch_enable_i,
+ output logic           core_sleep_o,
  output logic           core_busy_o
  );
 
@@ -118,6 +119,7 @@ module top
       .debug_req_i            ( debug_req_i           ),
 
       .fetch_enable_i         ( fetch_enable_i        ),
+      .core_sleep_o           ( core_sleep_o          ),
       .core_busy_o            ( core_busy_o           ),
 
       .fregfile_disable_i     ( 1'b0                  ));


### PR DESCRIPTION
Adde core_sleep_o pin indicating when the clock (clk_i) is allowed (but not required) to be gated externally. The initial state (during and out of reset) of core_sleep_o = 0; the core_sleep_o pin can only possibly be set to 1 in response to executing a WFI instruction.

Once core_sleep_o is 1 it will go to 0 again only for the following conditions:

PULP_CLUSTER = 0: Any pending interrupt or debug request (debug_req_i == 1)
PULP_CLUSTER = 1: clock_en_i == 1

The addition was slightly more complicated than suggested in #131 as the default state of clock_en is 0 during and closely after reset (and we do not want to indicate that the core is asleep during reset assertion nor when just coming out of reset before even an WFI has been executed). 

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>
