### PR TITLE
Made c.jr x0 an illegal instruction (as per the RISC-V spec)

### DIFF
--- a/rtl/riscv_compressed_decoder.sv
+++ b/rtl/riscv_compressed_decoder.sv
@@ -246,6 +246,8 @@ module riscv_compressed_decoder
               if (instr_i[6:2] == 5'b0) begin
                 // c.jr -> jalr x0, rd/rs1, 0
                 instr_o = {12'b0, instr_i[11:7], 3'b0, 5'b0, OPCODE_JALR};
+                // c.jr with rs1 = 0 is reserved
+                if (instr_i[11:7] == 5'b0) illegal_instr_o = 1'b1;
               end
             end else begin
               // c.add -> add rd, rd, rs2


### PR DESCRIPTION
Made c.jr x0 an illegal instruction (as per the RISC-V spec). This fixes the identical issues #137 and #187 

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>