### PR TITLE
Renamed riscv_core to cv32e40p_core

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -30,7 +30,7 @@ sources:
     - rtl/riscv_pmp.sv
     - rtl/riscv_prefetch_buffer.sv
     - rtl/riscv_prefetch_L0_buffer.sv
-    - rtl/riscv_core.sv
+    - rtl/cv32e40p_core.sv
     - rtl/riscv_apu_disp.sv
     - rtl/riscv_fetch_fifo.sv
     - rtl/riscv_L0_buffer.sv

--- a/cv32e40p_manifest.flist
+++ b/cv32e40p_manifest.flist
@@ -58,4 +58,4 @@ ${DESIGN_RTL_DIR}/riscv_popcnt.sv
 ${DESIGN_RTL_DIR}/riscv_pmp.sv
 ${DESIGN_RTL_DIR}/riscv_apu_disp.sv
 ${DESIGN_RTL_DIR}/riscv_controller.sv
-${DESIGN_RTL_DIR}/riscv_core.sv
+${DESIGN_RTL_DIR}/cv32e40p_core.sv

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -35,7 +35,7 @@ import apu_core_package::*;
 
 import riscv_defines::*;
 
-module riscv_core
+module cv32e40p_core
 #(
   parameter PULP_CLUSTER        =  0,
   parameter FPU                 =  0,

--- a/rtl/riscv_controller.sv
+++ b/rtl/riscv_controller.sv
@@ -210,7 +210,7 @@ module riscv_controller
   begin
     // print warning in case of decoding errors
     if (is_decoding_o && illegal_insn_i) begin
-      $display("%t: Illegal instruction (core %0d) at PC 0x%h:", $time, riscv_core.core_id_i,
+      $display("%t: Illegal instruction (core %0d) at PC 0x%h:", $time, cv32e40p_core.core_id_i,
                riscv_id_stage.pc_id_i);
     end
   end

--- a/src_files.yml
+++ b/src_files.yml
@@ -42,7 +42,7 @@ riscv:
     ./rtl/riscv_mult.sv,
     ./rtl/riscv_prefetch_buffer.sv,
     ./rtl/riscv_prefetch_L0_buffer.sv,
-    ./rtl/riscv_core.sv,
+    ./rtl/cv32e40p_core.sv,
     ./rtl/riscv_apu_disp.sv,
     ./rtl/riscv_fetch_fifo.sv,
     ./rtl/riscv_L0_buffer.sv,

--- a/tb/core/riscv_wrapper.sv
+++ b/tb/core/riscv_wrapper.sv
@@ -62,13 +62,13 @@ module riscv_wrapper
     assign debug_req_i = 1'b0;
 
     // instantiate the core
-    riscv_core
+    cv32e40p_core
         #(
           .PULP_CLUSTER(PULP_CLUSTER),
           .FPU(FPU),
           .PULP_ZFINX(PULP_ZFINX),
           .DM_HALTADDRESS(DM_HALTADDRESS))
-    riscv_core_i
+    cv32e40p_core_i
         (
          .clk_i                  ( clk_i                 ),
          .rst_ni                 ( rst_ni                ),
@@ -158,7 +158,7 @@ module riscv_wrapper
          .irq_nmi_o      ( irq_nmi                        ),
          .irq_fastx_o    ( irq_fastx                      ),
 
-         .pc_core_id_i   ( riscv_core_i.pc_id             ),
+         .pc_core_id_i   ( cv32e40p_core_i.pc_id          ),
 
          .tests_passed_o ( tests_passed_o                 ),
          .tests_failed_o ( tests_failed_o                 ),

--- a/tb/core/software.tcl
+++ b/tb/core/software.tcl
@@ -1,5 +1,5 @@
 # add fc execution trace
-set rvcores [find instances -recursive -bydu riscv_core -nodu]
+set rvcores [find instances -recursive -bydu cv32e40p_core -nodu]
 set fpuprivate [find instances -recursive -bydu fpu_private]
 
 if {$rvcores ne ""} {

--- a/tb/core/waves.tcl
+++ b/tb/core/waves.tcl
@@ -11,7 +11,7 @@
 # }
 
 # add fc
-set rvcores [find instances -recursive -bydu riscv_core -nodu]
+set rvcores [find instances -recursive -bydu cv32e40p_core -nodu]
 set fpuprivate [find instances -recursive -bydu fpu_private]
 set tb_top [find instances -recursive -bydu tb_top -nod]
 set mm_ram [find instances -recursive -bydu mm_ram -nod]


### PR DESCRIPTION
RTL update for https://github.com/openhwgroup/core-v-docs/issues/51

Only the module renaming was done. The other topics raised (e.g. license, ifdefs) are not related to documentation and will be handled separately.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>