### PR TITLE
read only CSRs should return illegal instruction when written

### DIFF
--- a/rtl/riscv_decoder.sv
+++ b/rtl/riscv_decoder.sv
@@ -2418,6 +2418,13 @@ module riscv_decoder
               FPREC :
                 if(!FPU) csr_illegal = 1'b1;
 
+            //  Writes to read only CSRs results in illegal instruction
+            CSR_MVENDORID,
+              CSR_MARCHID,
+              CSR_MIMPID,
+              CSR_MHARTID :
+                if(csr_op != CSR_OP_READ) csr_illegal = 1'b1;
+
             // These are valid CSR registers
             CSR_MSTATUS,
               CSR_MISA,
@@ -2431,10 +2438,6 @@ module riscv_decoder
               CSR_MTVAL,
               CSR_MIP,
               CSR_MIPX,
-              CSR_MVENDORID,
-              CSR_MARCHID,
-              CSR_MIMPID,
-              CSR_MHARTID,
               CSR_MCOUNTEREN,
 
               UHARTID,


### PR DESCRIPTION
Fixes #335 , where writing to a read only CSR should return an illegal instruction. These read only CSRs include:
- mvendorid
- marchid
- mimpid
- mhartid


Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>