### PR TITLE
improved tb for interrupt tests

### DIFF
--- a/tb/core/Makefile
+++ b/tb/core/Makefile
@@ -315,6 +315,7 @@ custom-fp-vsim-run-gui: vsim-run-gui-fp
 # compile and run interrupt_test
 interrupt_test/interrupt_test.elf: interrupt_test/interrupt_test.c
 	$(RISCV_EXE_PREFIX)gcc -march=rv32imc -o $@ -w -Os -g -nostdlib \
+		$(CUSTOM_GCC_FLAGS) \
 		-T custom/link.ld  \
 		-static \
 		custom/crt0.S \

--- a/tb/core/cv32e40p_wrapper.sv
+++ b/tb/core/cv32e40p_wrapper.sv
@@ -153,6 +153,7 @@ module cv32e40p_wrapper
          .irq_fast_o     ( irq_fast                       ),
 
          .pc_core_id_i   ( core_i.pc_id                   ),
+         .is_pulp_obi    ( core_i.PULP_OBI                ),
 
          .tests_passed_o ( tests_passed_o                 ),
          .tests_failed_o ( tests_failed_o                 ),

--- a/tb/core/interrupt_test/interrupt_test.c
+++ b/tb/core/interrupt_test/interrupt_test.c
@@ -515,8 +515,55 @@ void mat_mult(uint32_t mat1[MAT_DIM][MAT_DIM], uint32_t mat2[MAT_DIM][MAT_DIM], 
     }
 }
 
+void activate_random_stall(void)
+{
+  // Address vector for rnd_stall_reg, to control memory stalls/interrupt
+  volatile unsigned int *rnd_stall_reg[16];
+
+  // Setup the address vector
+  rnd_stall_reg[0] = 0x16000000;
+  for (int i = 1; i < 16; i++) {
+    rnd_stall_reg[i] = rnd_stall_reg[i-1] + 1; // It is a pointer to int ("+ 1" means "the next int")
+  }
+
+  /* The interposition of the stall generator between CPU and MEM should happen BEFORE the stall generetor is active */
+  // Interpose the stall generator between CPU and D-MEM (rnd_stall_reg[1])
+  *rnd_stall_reg[1] = 0x01;
+  // Interpose the stall generator between CPU and I-MEM (rnd_stall_reg[0])
+  *rnd_stall_reg[0] = 0x01;
+
+  // DATA MEMORY
+  // Set max n. stalls on both GNT and VALID for RANDOM mode (rnd_stall_reg[5])
+  *rnd_stall_reg[5] = 0x0a;
+  // Set n. stalls on  GNT (rnd_stall_reg[7])
+  *rnd_stall_reg[7] = 0x00;
+  // Set n. stalls on VALID (rnd_stall_reg[9])
+  *rnd_stall_reg[9] = 0x00;
+
+  // INSTRUCTION MEMORY
+  // Set max n. stalls on both GNT and VALID for RANDOM mode (rnd_stall_reg[4])
+  *rnd_stall_reg[4] = 0x0a;
+  // Set n. stalls on  GNT (rnd_stall_reg[6])
+  *rnd_stall_reg[6] = 0x00;
+  // Set n. stalls on VALID (rnd_stall_reg[8])
+  *rnd_stall_reg[8] = 0x00;
+
+  /* Activating stalls on D and I Mem has to be done as last operation. Do not change the order. */
+  // Set stall mode on D-MEM (off=0, standard=1, random=2) (rnd_stall_reg[3])
+  *rnd_stall_reg[3] = 0x02;
+  // Set stall mode on I-MEM (off=0, standard=1, random=2) (rnd_stall_reg[2])
+  *rnd_stall_reg[2] = 0x02;
+}
+
 int main(int argc, char *argv[])
 {
+
+#ifdef RANDOM_MEM_STALL
+    printf("ACTIVATING RANDOM D/I MEMORY STALLS: ");
+    activate_random_stall();
+    printf("OK\n");
+#endif
+
     printf("TEST 1 - TRIGGER ALL IRQS IN SEQUENCE: ");
 
     // Enable all mie (need to store)

--- a/tb/core/mm_ram.sv
+++ b/tb/core/mm_ram.sv
@@ -46,7 +46,7 @@ module mm_ram
      output logic [47:0]                  irq_fast_o,
 
      input logic [31:0]                   pc_core_id_i,
-
+     input logic                          is_pulp_obi,
      output logic                         tests_passed_o,
      output logic                         tests_failed_o,
      output logic                         exit_valid_o,
@@ -294,6 +294,7 @@ module mm_ram
 
                 // write to rnd stall regs
                 end else if (data_addr_i[31:16] == 16'h1600) begin
+                    if(~is_pulp_obi) begin $fatal("[RANDOM STALL] Not SUPPORTED RANDOM STALL FOR OBI at the moment"); $stop; end
                     rnd_stall_req   = data_req_i;
                     rnd_stall_wdata = data_wdata_i;
                     rnd_stall_addr  = data_addr_i;
@@ -314,8 +315,8 @@ module mm_ram
                     data_atop_dec  = data_atop_i;
                     transaction    = T_RAM;
                 end else if (data_addr_i[31:16] == 16'h1600) begin
+                    if(~is_pulp_obi) begin $fatal("[RANDOM STALL] Not SUPPORTED RANDOM STALL FOR OBI at the moment"); $stop; end
                     select_rdata_d = RND_STALL;
-
                     rnd_stall_req      = data_req_i;
                     rnd_stall_wdata    = data_wdata_i;
                     rnd_stall_addr     = data_addr_i;


### PR DESCRIPTION
Added random stalls in interrupts
Stopping simulation when PULP_OBI=0 is used in RANDOM Stalls as it's not supported yet