### PR TITLE
Fix "interrupt + random_mem_stalls" test for PULP_OBI == 0

### DIFF
--- a/tb/core/Makefile
+++ b/tb/core/Makefile
@@ -106,6 +106,7 @@ CSMITH_TIMEOUT_VERI      = 100
 
 # GCC configuration
 CUSTOM_GCC_FLAGS           =
+INTERRUPT_GCC_FLAGS        =
 
 all: firmware-veri-run
 
@@ -261,8 +262,9 @@ custom/hello_world.elf: custom/hello_world.c
 		-T custom/link.ld \
 		-static \
 		custom/crt0.S \
-		$^ custom/syscalls.c custom/vectors.S \
+		$^ mem_stall/mem_stall.c custom/syscalls.c custom/vectors.S \
 		-I $(RISCV)/riscv32-unknown-elf/include \
+		-I mem_stall \
 		-L $(RISCV)/riscv32-unknown-elf/lib \
 		-lc -lm -lgcc
 custom-clean:
@@ -315,11 +317,13 @@ custom-fp-vsim-run-gui: vsim-run-gui-fp
 # compile and run interrupt_test
 interrupt_test/interrupt_test.elf: interrupt_test/interrupt_test.c
 	$(RISCV_EXE_PREFIX)gcc -march=rv32imc -o $@ -w -Os -g -nostdlib \
+		${INTERRUPT_GCC_FLAGS} \
 		-T custom/link.ld  \
 		-static \
 		custom/crt0.S \
-		$^ custom/syscalls.c interrupt_test/vectors.S \
+		$^ mem_stall/mem_stall.c custom/syscalls.c interrupt_test/vectors.S \
 		-I $(RISCV)/riscv32-unknown-elf/include \
+		-I mem_stall/ \
 		-L $(RISCV)/riscv32-unknown-elf/lib \
 		-lc -lm -lgcc
 interrupt-clean:

--- a/tb/core/custom/hello_world.c
+++ b/tb/core/custom/hello_world.c
@@ -1,43 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-
-void activate_random_stall(void)
-{
-  // Address vector for rnd_stall_reg, to control memory stalls/interrupt
-  volatile unsigned int *rnd_stall_reg[16];
-
-  // Setup the address vector
-  rnd_stall_reg[0] = 0x16000000;
-  for (int i = 1; i < 16; i++) {
-    rnd_stall_reg[i] = rnd_stall_reg[i-1] + 1; // It is a pointer to int ("+ 1" means "the next int")
-  }
-
-  // INSTRUCTION MEMORY
-  // Set stall mode (standard=1, random=2) (rnd_stall_reg[2])
-  *rnd_stall_reg[2] = 0x02;
-  // Set max n. stalls on both GNT and VALID for RANDOM mode (rnd_stall_reg[4])
-  *rnd_stall_reg[4] = 0x0a;
-  // Set n. stalls on  GNT (rnd_stall_reg[6])
-  *rnd_stall_reg[6] = 0x00;
-  // Set n. stalls on VALID (rnd_stall_reg[8])
-  *rnd_stall_reg[8] = 0x00;
-
-  // DATA MEMORY
-  // Set stall mode (standard=1, random=2) (rnd_stall_reg[3])
-  *rnd_stall_reg[3] = 0x02;
-  // Set max n. stalls on both GNT and VALID for RANDOM mode (rnd_stall_reg[5])
-  *rnd_stall_reg[5] = 0x0a;
-  // Set n. stalls on  GNT (rnd_stall_reg[7])
-  *rnd_stall_reg[7] = 0x00;
-  // Set n. stalls on VALID (rnd_stall_reg[9])
-  *rnd_stall_reg[9] = 0x00;
-
-  /* Activating stalls on D and I Mem has to be done as last operation. Do not change the order. */
-  // Enable/disable stalls on D-MEM (rnd_stall_reg[1])
-  *rnd_stall_reg[1] = 0x01;
-  // Enable/disable stalls on I-MEM (rnd_stall_reg[0])
-  *rnd_stall_reg[0] = 0x01;
-}
+#include "mem_stall.h"
 
 int main(int argc, char *argv[])
 {

--- a/tb/core/interrupt_test/interrupt_test.c
+++ b/tb/core/interrupt_test/interrupt_test.c
@@ -4,6 +4,7 @@
 
 #include "isr.h"
 #include "matrix.h"
+#include "mem_stall.h"
 
 #define ERR_CODE_TEST_2      2
 #define ERR_CODE_TEST_3      3
@@ -517,6 +518,13 @@ void mat_mult(uint32_t mat1[MAT_DIM][MAT_DIM], uint32_t mat2[MAT_DIM][MAT_DIM], 
 
 int main(int argc, char *argv[])
 {
+
+#ifdef RANDOM_MEM_STALL
+    printf("ACTIVATING RANDOM D/I MEMORY STALLS: ");
+    activate_random_stall();
+    printf("OK\n");
+#endif
+
     printf("TEST 1 - TRIGGER ALL IRQS IN SEQUENCE: ");
 
     // Enable all mie (need to store)

--- a/tb/core/mem_stall/mem_stall.c
+++ b/tb/core/mem_stall/mem_stall.c
@@ -1,0 +1,56 @@
+/*
+* Copyright 2020 ETH Zürich and University of Bologna
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// This routine enables random stalls on both I-MEM and D-MEM
+void activate_random_stall(void)
+{
+  // Address vector for rnd_stall_reg, to control memory stalls/interrupt
+  volatile unsigned int *rnd_stall_reg_ptr[16];
+
+  // Setup the address vector
+  rnd_stall_reg_ptr[0] = (unsigned int *) 0x16000000;
+  for (int i = 1; i < 16; i++) {
+    rnd_stall_reg_ptr[i] = rnd_stall_reg_ptr[i-1] + 1; // It is a pointer to int ("+ 1" means "the next int")
+  }
+
+  /* The interposition of the stall generator between CPU and MEM should happen BEFORE the stall generetor is active */
+  // Interpose the stall generator between CPU and D-MEM (rnd_stall_reg[1])
+  *rnd_stall_reg_ptr[1] = 0x01;
+  // Interpose the stall generator between CPU and I-MEM (rnd_stall_reg[0])
+  *rnd_stall_reg_ptr[0] = 0x01;
+
+  // DATA MEMORY
+  // Set max n. stalls on both GNT and VALID for RANDOM mode (rnd_stall_reg[5])
+  *rnd_stall_reg_ptr[5] = 0x0a;
+  // Set n. stalls on  GNT (rnd_stall_reg[7])
+  *rnd_stall_reg_ptr[7] = 0x00;
+  // Set n. stalls on VALID (rnd_stall_reg[9])
+  *rnd_stall_reg_ptr[9] = 0x00;
+
+  // INSTRUCTION MEMORY
+  // Set max n. stalls on both GNT and VALID for RANDOM mode (rnd_stall_reg[4])
+  *rnd_stall_reg_ptr[4] = 0x0a;
+  // Set n. stalls on  GNT (rnd_stall_reg[6])
+  *rnd_stall_reg_ptr[6] = 0x00;
+  // Set n. stalls on VALID (rnd_stall_reg[8])
+  *rnd_stall_reg_ptr[8] = 0x00;
+
+  /* Activating stalls on D and I Mem has to be done as last operation. Do not change the order. */
+  // Set stall mode on D-MEM (off=0, standard=1, random=2) (rnd_stall_reg[3])
+  *rnd_stall_reg_ptr[3] = 0x02;
+  // Set stall mode on I-MEM (off=0, standard=1, random=2) (rnd_stall_reg[2])
+  *rnd_stall_reg_ptr[2] = 0x02;
+}

--- a/tb/core/mem_stall/mem_stall.h
+++ b/tb/core/mem_stall/mem_stall.h
@@ -1,0 +1,3 @@
+// Header file for the memory stalls support
+
+void activate_random_stall(void);

--- a/tb/core/mm_ram.sv
+++ b/tb/core/mm_ram.sv
@@ -58,10 +58,7 @@ module mm_ram
     localparam int                        IRQ_MAX_ID     = 34;
     localparam int                        IRQ_MIN_ID     = 29;
 
-    // mux for read and writes
-    enum logic [1:0]{RAM, PER, RND_STALL, ERR} select_rdata_d, select_rdata_q;
-
-    typedef enum logic {T_RAM, T_PER} transaction_t;
+    typedef enum logic [1:0] {T_RAM, T_PER, T_RND_STALL, T_ERR} transaction_t;
     transaction_t transaction, granted_transaction, completed_transaction;
     mailbox #( transaction_t) granted_transactions = new();
     mailbox #( transaction_t) completed_transactions = new();
@@ -155,6 +152,12 @@ module mm_ram
     logic                          rnd_stall_data_we;
     logic [3:0]                    rnd_stall_data_be;
 
+    // sampled rnd_stall_addr
+    logic [31:0]                   rnd_stall_addr_q;
+
+    // sampled data_addr_i for coherent error reporting
+    logic [31:0]                   error_addr_q;
+
     // IRQ related internal signals
 
     // struct irq_lines
@@ -207,7 +210,6 @@ module mm_ram
         rnd_stall_addr      = '0;
         rnd_stall_wdata     = '0;
         rnd_stall_we        = '0;
-        select_rdata_d      = RAM;
         transaction         = T_PER;
 
         if (data_req_i) begin
@@ -304,8 +306,6 @@ module mm_ram
 
             end else begin // handle reads
                 if (data_addr_i < 2 ** RAM_ADDR_WIDTH) begin
-                    select_rdata_d = RAM;
-
                     data_req_dec   = data_req_i;
                     data_addr_dec  = data_addr_i[RAM_ADDR_WIDTH-1:0];
                     data_wdata_dec = data_wdata_i;
@@ -314,18 +314,39 @@ module mm_ram
                     data_atop_dec  = data_atop_i;
                     transaction    = T_RAM;
                 end else if (data_addr_i[31:16] == 16'h1600) begin
-                    select_rdata_d = RND_STALL;
-
                     rnd_stall_req      = data_req_i;
                     rnd_stall_wdata    = data_wdata_i;
                     rnd_stall_addr     = data_addr_i;
                     rnd_stall_we       = data_we_i;
-
+                    transaction    = T_RND_STALL;
                 end else if (data_addr_i[31:00] == 32'h1500_1000) begin
-                    select_rdata_d = PER;
+                    transaction    = T_PER;
                 end else
-                    select_rdata_d = ERR;
+                    transaction    = T_ERR;
+            end
+        end
+    end
 
+    // Store rnd_stall_addr when the processor wants to read a rnd_stall_reg
+    // This is useful if the request is delayed because of a memory stall
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(!rst_ni) begin
+            rnd_stall_addr_q <= '0;
+        end else begin
+            if (transaction == T_RND_STALL) begin
+                rnd_stall_addr_q <= rnd_stall_addr;
+            end
+        end
+    end
+
+    // Store data_addr_i when the processor wants to read a rnd_stall_reg
+    // This is useful if the request is delayed because of a memory stall
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(!rst_ni) begin
+            error_addr_q <= '0;
+        end else begin
+            if (transaction != T_RAM) begin
+                error_addr_q <= data_addr_i;
             end
         end
     end
@@ -352,24 +373,24 @@ module mm_ram
     always_comb begin: read_mux
         data_rdata_o = '0;
 
-        if(select_rdata_q == RAM) begin
+        if(response_phase && granted_transaction == T_RAM) begin
             data_rdata_o = core_data_rdata;
-        end else if(select_rdata_q == RND_STALL) begin
+        end else if(response_phase && granted_transaction == T_RND_STALL) begin
 `ifndef VERILATOR
             data_rdata_o = rnd_stall_rdata;
 `else
-            $display("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", data_addr_i);
+            $display("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", error_addr_q);
             $fatal(2);
 `endif
-        end else if(select_rdata_q == PER) begin
+        end else if(response_phase && granted_transaction == T_PER) begin
 `ifndef VERILATOR
             data_rdata_o = $urandom();
 `else
-            $display("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", data_addr_i);
+            $display("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", error_addr_q);
             $fatal(2);
 `endif
-        end else if (select_rdata_q == ERR) begin
-            $display("out of bounds read from %08x", data_addr_i);
+        end else if (response_phase && granted_transaction == T_ERR) begin
+            $display("out of bounds read from %08x", error_addr_q);
             $fatal(2);
         end
     end
@@ -421,7 +442,7 @@ module mm_ram
                 if(rnd_stall_we)
                     rnd_stall_regs[rnd_stall_addr[5:2]] <= rnd_stall_wdata;
                 else
-                    rnd_stall_rdata <= rnd_stall_regs[rnd_stall_addr[5:2]];
+                    rnd_stall_rdata <= rnd_stall_regs[rnd_stall_addr_q[5:2]];
             end else begin
                 if(timer_cnt_q > 0)
                     timer_cnt_q <= timer_cnt_q - 1;
@@ -559,11 +580,9 @@ module mm_ram
 
     always_ff @(posedge clk_i, negedge rst_ni) begin
         if (~rst_ni) begin
-            select_rdata_q <= RAM;
             data_rvalid_q  <= '0;
             instr_rvalid_q <= '0;
         end else begin
-            select_rdata_q <= select_rdata_d;
             data_rvalid_q  <= ram_data_req;
             instr_rvalid_q <= ram_instr_req;
         end


### PR DESCRIPTION
1) Refactor the _random memory stall_ support
2) Add _random memory stall_ support to _interrupt test_
3) **Exit success** in _interrupt test_ for both _PULP_OBI == 0_ and _PULP_OBI == 1_