### PR TITLE
Fixed mtvec bug

### DIFF
--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -1001,7 +1001,8 @@ end else begin //PULP_SECURE == 0
       end
       // mtvec: machine trap-handler base address
       CSR_MTVEC: if (csr_we_int) begin
-        mtvec_n    = csr_wdata_int[31:8];
+        mtvec_n      = csr_wdata_int[31:8];
+        mtvec_mode_n = {1'b0, csr_wdata_int[0]}; // Only direct and vectored mode are supported
       end
       // mscratch: machine scratch
       CSR_MSCRATCH: if (csr_we_int) begin

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -152,7 +152,7 @@ module cv32e40p_if_stage
 
     unique case (exc_pc_mux_i)
       EXC_PC_EXCEPTION:                        exc_pc = { trap_base_addr, 8'h0 }; //1.10 all the exceptions go to base address
-      EXC_PC_IRQ:                              exc_pc = { trap_base_addr, 1'b0,IGNORE_CAUSE_MSB ? {1'b0, exc_vec_pc_mux[4:0]} : exc_vec_pc_mux[5:0], 2'b0 }; // interrupts are vectored
+      EXC_PC_IRQ:                              exc_pc = { trap_base_addr, IGNORE_CAUSE_MSB ? {1'b0, exc_vec_pc_mux[4:0]} : exc_vec_pc_mux[5:0], 2'b0 }; // interrupts are vectored
       EXC_PC_DBD:                              exc_pc = { dm_halt_addr_i, 2'b0 };
       default:                                 exc_pc = { trap_base_addr, 8'h0 };
     endcase

--- a/tb/core/custom/crt0.S
+++ b/tb/core/custom/crt0.S
@@ -25,8 +25,9 @@ _start:
 /* initialize stack pointer */
 	la sp, _sp
 
-/* set vector table address */
+/* set vector table address and vectored mode */
 	la a0, __vector_start
+        ori a0, a0, 0x1
 	csrw mtvec, a0
 
 /* clear the bss segment */


### PR DESCRIPTION
Fixed mtvec; mode was not updated in the non-user section of the CSR file; due to typo the vectored address was shifted by one bit position. (Both issues were masked by tb/core/interrupt_test as it used mtvec set to 0 (so that the shift remained unnoticed; this I locally checked but did not push) and because vectored mode was not used (fixed that in the assembly). 

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>