### PR TITLE
Add `tinfo` debug CSR

### DIFF
--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -254,9 +254,9 @@ module cv32e40p_cs_registers
   logic [31:0] mepc_q, mepc_n;
   logic [31:0] uepc_q, uepc_n;
   // Trigger
-  logic [ 3:0] tmatch_control_type;
   logic [31:0] tmatch_control_rdata;
   logic [31:0] tmatch_value_rdata;
+  logic [15:0] tinfo_types;
   // Debug
   Dcsr_t       dcsr_q, dcsr_n;
   logic [31:0] depc_q, depc_n;
@@ -421,7 +421,7 @@ if(PULP_SECURE==1) begin
       CSR_TDATA2:
                csr_rdata_int = tmatch_value_rdata;
       CSR_TINFO:
-               csr_rdata_int = 1'b1 << tmatch_control_type;
+               csr_rdata_int = tinfo_types;
 
       CSR_DCSR:
                csr_rdata_int = dcsr_q;//
@@ -587,7 +587,7 @@ end else begin //PULP_SECURE == 0
       CSR_TDATA2:
                csr_rdata_int = tmatch_value_rdata;
       CSR_TINFO:
-               csr_rdata_int = 1'b1 << tmatch_control_type;
+               csr_rdata_int = tinfo_types;
 
       CSR_DCSR:
                csr_rdata_int = dcsr_q;//
@@ -1387,12 +1387,14 @@ end //PULP_SECURE
      end
     end
 
+    // All supported trigger types
+    assign tinfo_types = 1 << TTYPE_MCONTROL;
+
     // Assign read data
     // TDATA0 - only support simple address matching
-    assign tmatch_control_type = 4'h2; // type    : address/data match
     assign tmatch_control_rdata =
                {
-                tmatch_control_type,
+                TTYPE_MCONTROL,        // type    : address/data match
                 1'b1,                  // dmode   : access from D mode only
                 6'h00,                 // maskmax : exact match only
                 1'b0,                  // hit     : not supported
@@ -1419,7 +1421,7 @@ end //PULP_SECURE
                               (pc_id_i[31:0] == tmatch_value_q[31:0]);
 
   end else begin : gen_no_trigger_regs
-    assign tmatch_control_type  = 'b0;
+    assign tinfo_types          = 'b0;
     assign tmatch_control_rdata = 'b0;
     assign tmatch_value_rdata   = 'b0;
     assign trigger_match_o      = 'b0;

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -254,6 +254,7 @@ module cv32e40p_cs_registers
   logic [31:0] mepc_q, mepc_n;
   logic [31:0] uepc_q, uepc_n;
   // Trigger
+  logic [ 3:0] tmatch_control_type;
   logic [31:0] tmatch_control_rdata;
   logic [31:0] tmatch_value_rdata;
   // Debug
@@ -419,6 +420,8 @@ if(PULP_SECURE==1) begin
                csr_rdata_int = tmatch_control_rdata;
       CSR_TDATA2:
                csr_rdata_int = tmatch_value_rdata;
+      CSR_TINFO:
+               csr_rdata_int = 1'b1 << tmatch_control_type;
 
       CSR_DCSR:
                csr_rdata_int = dcsr_q;//
@@ -583,6 +586,8 @@ end else begin //PULP_SECURE == 0
                csr_rdata_int = tmatch_control_rdata;
       CSR_TDATA2:
                csr_rdata_int = tmatch_value_rdata;
+      CSR_TINFO:
+               csr_rdata_int = 1'b1 << tmatch_control_type;
 
       CSR_DCSR:
                csr_rdata_int = dcsr_q;//
@@ -1384,9 +1389,10 @@ end //PULP_SECURE
 
     // Assign read data
     // TDATA0 - only support simple address matching
+    assign tmatch_control_type = 4'h2; // type    : address/data match
     assign tmatch_control_rdata =
                {
-                4'h2,                  // type    : address/data match
+                tmatch_control_type,
                 1'b1,                  // dmode   : access from D mode only
                 6'h00,                 // maskmax : exact match only
                 1'b0,                  // hit     : not supported
@@ -1413,6 +1419,7 @@ end //PULP_SECURE
                               (pc_id_i[31:0] == tmatch_value_q[31:0]);
 
   end else begin : gen_no_trigger_regs
+    assign tmatch_control_type  = 'b0;
     assign tmatch_control_rdata = 'b0;
     assign tmatch_value_rdata   = 'b0;
     assign trigger_match_o      = 'b0;

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -2486,6 +2486,7 @@ module cv32e40p_decoder
               CSR_TDATA1    ,
               CSR_TDATA2    ,
               CSR_TDATA3    ,
+              CSR_TINFO     ,
               CSR_MCONTEXT  ,
               CSR_SCONTEXT  :
                 if(!debug_mode_i || DEBUG_TRIGGER_EN != 1)

--- a/rtl/include/cv32e40p_defines.sv
+++ b/rtl/include/cv32e40p_defines.sv
@@ -582,6 +582,14 @@ typedef enum logic[3:0] {
    XDEBUGVER_NONSTD = 4'd15 // debug not conforming to RISC-V debug spec
 } x_debug_ver_e;
 
+// Trigger types
+typedef enum logic [3:0] {
+  TTYPE_MCONTROL = 4'h2,
+  TTYPE_ICOUNT = 4'h3,
+  TTYPE_ITRIGGER = 4'h4,
+  TTYPE_ETRIGGER = 4'h5
+} trigger_type_e;
+
 
 /////////////////////////////////////
 // THIS PART IS OBSOLETED BY FPNEW //

--- a/rtl/include/cv32e40p_defines.sv
+++ b/rtl/include/cv32e40p_defines.sv
@@ -265,6 +265,7 @@ typedef enum logic[11:0] {
   CSR_TDATA1    = 12'h7A1,
   CSR_TDATA2    = 12'h7A2,
   CSR_TDATA3    = 12'h7A3,
+  CSR_TINFO     = 12'h7A4,
   CSR_MCONTEXT  = 12'h7A8,
   CSR_SCONTEXT  = 12'h7AA,
 


### PR DESCRIPTION
The [RISC-V debug specification, Section 5.2.5](https://github.com/riscv/riscv-debug-spec/raw/release/riscv-debug-release.pdf) defines the *Trigger Info* register, which returns the trigger types supported by the currently selected trigger.  CV32E40P implements *address/data match* triggers (or no triggers if `DEBUG_TRIGGER_EN` is disabled), and this PR exposes the supported trigger in a newly added `tinfo` CSR.