### PR TITLE
Added/corrected sleep interface; fixed #373, #362, #379

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -36,6 +36,7 @@ sources:
     - rtl/cv32e40p_fetch_fifo.sv
     - rtl/cv32e40p_popcnt.sv
     - rtl/cv32e40p_ff_one.sv
+    - rtl/cv32e40p_sleep_unit.sv
     - target: asic
       files:
         - rtl/cv32e40p_register_file_latch.sv

--- a/cv32e40p_manifest.flist
+++ b/cv32e40p_manifest.flist
@@ -58,4 +58,5 @@ ${DESIGN_RTL_DIR}/cv32e40p_apu_disp.sv
 ${DESIGN_RTL_DIR}/cv32e40p_controller.sv
 ${DESIGN_RTL_DIR}/cv32e40p_obi_interface.sv
 ${DESIGN_RTL_DIR}/cv32e40p_prefetch_controller.sv
+${DESIGN_RTL_DIR}/cv32e40p_sleep_unit.sv
 ${DESIGN_RTL_DIR}/cv32e40p_core.sv

--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -32,7 +32,7 @@ import cv32e40p_defines::*;
 
 module cv32e40p_controller
 #(
-  parameter FPU               = 0
+  parameter PULP_CLUSTER = 0
 )
 (
   input  logic        clk,
@@ -40,7 +40,6 @@ module cv32e40p_controller
 
   input  logic        fetch_enable_i,             // Start the decoding
   output logic        ctrl_busy_o,                // Core is busy processing instructions
-  output logic        first_fetch_o,              // Core is at the FIRST FETCH stage
   output logic        is_decoding_o,              // Core is in decoding state
   input  logic        is_fetch_failed_i,
 
@@ -119,7 +118,6 @@ module cv32e40p_controller
 
   // Debug Signal
   output logic         debug_mode_o,
-  output logic         debug_req_pending_o,
   output logic [2:0]   debug_cause_o,
   output logic         debug_csr_save_o,
   input  logic         debug_req_i,
@@ -127,6 +125,8 @@ module cv32e40p_controller
   input  logic         debug_ebreakm_i,
   input  logic         debug_ebreaku_i,
   input  logic         trigger_match_i,
+  output logic         debug_p_elw_no_sleep_o,
+  output logic         debug_wfi_no_sleep_o,
 
   // Wakeup Signal
   output logic        wake_from_sleep_o,
@@ -207,6 +207,7 @@ module cv32e40p_controller
   logic instr_valid_irq_flush_n, instr_valid_irq_flush_q;
 
   logic debug_req_q;
+  logic debug_req_pending;
 
 `ifndef SYNTHESIS
   // synopsys translate_off
@@ -266,7 +267,6 @@ module cv32e40p_controller
     ctrl_fsm_ns            = ctrl_fsm_cs;
 
     ctrl_busy_o            = 1'b1;
-    first_fetch_o          = 1'b0;
 
     halt_if_o              = 1'b0;
     halt_id_o              = 1'b0;
@@ -341,24 +341,22 @@ module cv32e40p_controller
         // we begin execution when an
         // interrupt has arrived
         is_decoding_o = 1'b0;
-        ctrl_busy_o   = 1'b0;
         instr_req_o   = 1'b0;
         halt_if_o     = 1'b1;
         halt_id_o     = 1'b1;
 
-
         // normal execution flow
         // in debug mode or single step mode we leave immediately (wfi=nop)
-        if (wake_from_sleep_o ) begin
-          ctrl_fsm_ns  = FIRST_FETCH;
+        if (wake_from_sleep_o) begin
+          ctrl_fsm_ns = FIRST_FETCH;
+        end else begin
+          ctrl_busy_o = 1'b0;
         end
-
       end
 
       FIRST_FETCH:
       begin
         is_decoding_o = 1'b0;
-        first_fetch_o = 1'b1;
         // Stall because of IF miss
         if ((id_ready_i == 1'b1) )
         begin
@@ -374,7 +372,7 @@ module cv32e40p_controller
           halt_id_o   = 1'b1;
         end
 
-        if ((debug_req_pending_o || trigger_match_i) & (~debug_mode_q))
+        if ((debug_req_pending || trigger_match_i) & (~debug_mode_q))
         begin
           ctrl_fsm_ns = DBG_TAKEN_IF;
           halt_if_o   = 1'b1;
@@ -449,7 +447,7 @@ module cv32e40p_controller
               //irq_req_ctrl_i comes from a FF in the interrupt controller
               //irq_enable_int: check again irq_enable_int because xIE could have changed
               //don't serve in debug mode
-              irq_req_ctrl_i & irq_enable_int & (~debug_req_pending_o) & (~debug_mode_q):
+              irq_req_ctrl_i & irq_enable_int & (~debug_req_pending) & (~debug_mode_q):
               begin
                 //Serving the external interrupt
                 halt_if_o     = 1'b1;
@@ -459,7 +457,7 @@ module cv32e40p_controller
               end
 
 
-              (debug_req_pending_o || trigger_match_i) & (~debug_mode_q):
+              (debug_req_pending || trigger_match_i) & (~debug_mode_q):
               begin
                 //Serving the debug
                 halt_if_o     = 1'b1;
@@ -699,7 +697,7 @@ module cv32e40p_controller
         //If an interrupt occurs, we replay the ELW
         //No needs to check irq_int_req_i since in the EX stage there is only the elw, no CSR pendings
         if(id_ready_i)
-          ctrl_fsm_ns = ((debug_req_pending_o || trigger_match_i) & ~debug_mode_q) ? DBG_FLUSH : IRQ_FLUSH_ELW;
+          ctrl_fsm_ns = ((debug_req_pending || trigger_match_i) & ~debug_mode_q) ? DBG_FLUSH : IRQ_FLUSH_ELW;
           // if from the ELW EXE we go to IRQ_FLUSH_ELW, it is assumed that if there was an IRQ req together with the grant and IE was valid, then
           // there must be no hazard due to xIE
         else
@@ -914,12 +912,12 @@ module cv32e40p_controller
         pc_set_o          = 1'b1;
         pc_mux_o          = PC_EXCEPTION;
         exc_pc_mux_o      = EXC_PC_DBD;
-        if (((debug_req_pending_o || trigger_match_i) && (~debug_mode_q)) ||
+        if (((debug_req_pending || trigger_match_i) && (~debug_mode_q)) ||
             (ebrk_insn_i && ebrk_force_debug_mode && (~debug_mode_q))) begin
             csr_save_cause_o = 1'b1;
             csr_save_id_o    = 1'b1;
             debug_csr_save_o = 1'b1;
-            if (debug_req_pending_o)
+            if (debug_req_pending)
                 debug_cause_o = DBG_CAUSE_HALTREQ;
             if (ebrk_insn_i)
                 debug_cause_o = DBG_CAUSE_EBREAK;
@@ -940,7 +938,7 @@ module cv32e40p_controller
         debug_csr_save_o  = 1'b1;
         if (debug_single_step_i)
             debug_cause_o = DBG_CAUSE_STEP;
-        if (debug_req_pending_o)
+        if (debug_req_pending)
             debug_cause_o = DBG_CAUSE_HALTREQ;
         if (ebrk_insn_i)
             debug_cause_o = DBG_CAUSE_EBREAK;
@@ -1129,11 +1127,21 @@ module cv32e40p_controller
   assign perf_ld_stall_o  = load_stall_o;
 
   // wakeup from sleep conditions
-  assign wake_from_sleep_o = irq_pending_i || debug_req_pending_o || debug_mode_q ;
+  assign wake_from_sleep_o = irq_pending_i || debug_req_pending || debug_mode_q;
 
   // debug mode
   assign debug_mode_o = debug_mode_q;
-  assign debug_req_pending_o = debug_req_i | debug_req_q;
+  assign debug_req_pending = debug_req_i || debug_req_q;
+
+  // Do not let p.elw cause core_sleep_o during debug
+  assign debug_p_elw_no_sleep_o = debug_mode_q || debug_req_q || debug_single_step_i || trigger_match_i;
+
+  // Do not let WFI cause core_sleep_o (but treat as NOP):
+  //
+  // - During debug
+  // - For PULP Cluster (only p.elw can trigger sleep)
+
+  assign debug_wfi_no_sleep_o = debug_mode_q || debug_req_pending || debug_single_step_i || trigger_match_i || PULP_CLUSTER;
 
   // sticky version of debug_req
   always_ff @(posedge clk , negedge rst_n)
@@ -1148,12 +1156,31 @@ module cv32e40p_controller
   //----------------------------------------------------------------------------
   // Assertions
   //----------------------------------------------------------------------------
+
+`ifndef VERILATOR
+
   // make sure that taken branches do not happen back-to-back, as this is not
   // possible without branch prediction in the IF stage
-  `ifndef VERILATOR
   assert property (
     @(posedge clk) (branch_taken_ex_i) |=> (~branch_taken_ex_i) ) else $warning("Two branches back-to-back are taken");
+
   assert property (
     @(posedge clk) (~('0 & irq_req_ctrl_i)) ) else $warning("Both dbg_req_i and irq_req_ctrl_i are active");
-  `endif
-endmodule // controller
+
+  // ELW_EXE and IRQ_FLUSH_ELW states are only used for PULP_CLUSTER = 1
+  property p_pulp_cluster_only_states;
+     @(posedge clk) (1'b1) |-> ( !((PULP_CLUSTER == 1'b0) && ((ctrl_fsm_cs == ELW_EXE) || (ctrl_fsm_cs == IRQ_FLUSH_ELW))) );
+  endproperty
+
+  a_pulp_cluster_only_states : assert property(p_pulp_cluster_only_states);
+
+  // WAIT_SLEEP and SLEEP states are never used for PULP_CLUSTER = 1
+  property p_pulp_cluster_excluded_states;
+     @(posedge clk) (1'b1) |-> ( !((PULP_CLUSTER == 1'b1) && ((ctrl_fsm_cs == SLEEP) || (ctrl_fsm_cs == WAIT_SLEEP))) );
+  endproperty
+
+  a_pulp_cluster_excluded_states : assert property(p_pulp_cluster_excluded_states);
+
+`endif
+
+endmodule // cv32e40p_controller

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -1237,41 +1237,45 @@ module cv32e40p_core
 `endif
 `endif
 
-  //----------------------------------------------------------------------------
-  // Assertions
-  //----------------------------------------------------------------------------
-
 `ifndef VERILATOR
 
-  // Check that IRQ indices which are reserved by the RISC-V privileged spec 
+  //----------------------------------------------------------------------------
+  // Assumptions
+  //----------------------------------------------------------------------------
+
+  // Assume that IRQ indices which are reserved by the RISC-V privileged spec 
   // or are meant for User or Hypervisor mode are not used (i.e. tied to 0)
   property p_no_reserved_irq;
      @(posedge clk_i) disable iff (!rst_ni) (1'b1) |-> ((irq_i[15:12] == 4'b0) && (irq_i[10:8] == 3'b0) && (irq_i[6:4] == 3'b0) && (irq_i[2:0] == 3'b0));
   endproperty
 
-  a_no_reserved_irq : assert property(p_no_reserved_irq);
+  a_no_reserved_irq : assume property(p_no_reserved_irq);
 
   generate
   if (PULP_CLUSTER) begin
 
-    // Requirements on the environment when pulp_clock_en_i = 0
+    // Assumptions/requirements on the environment when pulp_clock_en_i = 0
     property p_env_req_0;
        @(posedge clk_i) disable iff (!rst_ni) (pulp_clock_en_i == 1'b0) |-> (irq_i == 'b0) && (debug_req_i == 1'b0) &&
                                                                             (instr_rvalid_i == 1'b0) && (instr_gnt_i == 1'b0) &&
                                                                             (data_rvalid_i == 1'b0) && (data_gnt_i == 1'b0);
     endproperty
 
-    a_env_req_0 : assert property(p_env_req_0);
+    a_env_req_0 : assume property(p_env_req_0);
 
-    // Requirements on the environment when core_sleep_o = 0
+    // Assumptions/requirements on the environment when core_sleep_o = 0
     property p_env_req_1;
        @(posedge clk_i) disable iff (!rst_ni) (core_sleep_o == 1'b0) |-> (pulp_clock_en_i == 1'b1);
     endproperty
 
-    a_env_req_1 : assert property(p_env_req_1);
+    a_env_req_1 : assume property(p_env_req_1);
 
   end
   endgenerate
+
+  //----------------------------------------------------------------------------
+  // Assertions
+  //----------------------------------------------------------------------------
 
 `endif
 

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -1243,14 +1243,6 @@ module cv32e40p_core
   // Assumptions
   //----------------------------------------------------------------------------
 
-  // Assume that IRQ indices which are reserved by the RISC-V privileged spec 
-  // or are meant for User or Hypervisor mode are not used (i.e. tied to 0)
-  property p_no_reserved_irq;
-     @(posedge clk_i) disable iff (!rst_ni) (1'b1) |-> ((irq_i[15:12] == 4'b0) && (irq_i[10:8] == 3'b0) && (irq_i[6:4] == 3'b0) && (irq_i[2:0] == 3'b0));
-  endproperty
-
-  a_no_reserved_irq : assume property(p_no_reserved_irq);
-
   generate
   if (PULP_CLUSTER) begin
 

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -39,6 +39,7 @@ import cv32e40p_apu_core_package::*;
 
 module cv32e40p_id_stage
 #(
+  parameter PULP_CLUSTER      =  0,
   parameter PULP_HWLP         =  0,                     // PULP Hardware Loop present
   parameter N_HWLP            =  2,
   parameter N_HWLP_BITS       =  $clog2(N_HWLP),
@@ -69,7 +70,6 @@ module cv32e40p_id_stage
 
     input  logic        fetch_enable_i,
     output logic        ctrl_busy_o,
-    output logic        core_ctrl_firstfetch_o,
     output logic        is_decoding_o,
 
     // Interface to IF stage
@@ -233,6 +233,7 @@ module cv32e40p_id_stage
     input  logic        debug_ebreakm_i,
     input  logic        debug_ebreaku_i,
     input  logic        trigger_match_i,
+    output logic        debug_p_elw_no_sleep_o,
 
     // Wakeup Signal
     output logic        wake_from_sleep_o,
@@ -289,6 +290,7 @@ module cv32e40p_id_stage
   logic        hwloop_mask;
   logic        halt_id;
 
+  logic        debug_wfi_no_sleep;
 
   // Immediate decoding and sign extension
   logic [31:0] imm_i_type;
@@ -467,8 +469,6 @@ module cv32e40p_id_stage
   logic        mret_dec;
   logic        uret_dec;
   logic        dret_dec;
-
-  logic        debug_req_pending;
 
   assign instr = instr_rdata_i;
 
@@ -1027,8 +1027,6 @@ module cv32e40p_id_stage
   );
 
 
-
-
   ///////////////////////////////////////////////
   //  ____  _____ ____ ___  ____  _____ ____   //
   // |  _ \| ____/ ___/ _ \|  _ \| ____|  _ \  //
@@ -1040,6 +1038,7 @@ module cv32e40p_id_stage
 
   cv32e40p_decoder
     #(
+      .PULP_CLUSTER        ( PULP_CLUSTER         ),
       .PULP_HWLP           ( PULP_HWLP            ),
       .A_EXTENSION         ( A_EXTENSION          ),
       .FPU                 ( FPU                  ),
@@ -1165,9 +1164,7 @@ module cv32e40p_id_stage
 
     // debug mode
     .debug_mode_i                    ( debug_mode_o              ),
-    .debug_req_pending_i             ( debug_req_pending         ),
-    .debug_single_step_i             ( debug_single_step_i       ),
-    .trigger_match_i                 ( trigger_match_i           ),
+    .debug_wfi_no_sleep_i            ( debug_wfi_no_sleep        ),
 
     // jump/branches
     .jump_in_dec_o                   ( jump_in_dec               ),
@@ -1187,7 +1184,7 @@ module cv32e40p_id_stage
 
   cv32e40p_controller
   #(
-    .FPU ( FPU )
+    .PULP_CLUSTER ( PULP_CLUSTER )
   )
   controller_i
   (
@@ -1196,7 +1193,6 @@ module cv32e40p_id_stage
 
     .fetch_enable_i                 ( fetch_enable_i         ),
     .ctrl_busy_o                    ( ctrl_busy_o            ),
-    .first_fetch_o                  ( core_ctrl_firstfetch_o ),
     .is_decoding_o                  ( is_decoding_o          ),
     .is_fetch_failed_i              ( is_fetch_failed_i      ),
 
@@ -1276,7 +1272,6 @@ module cv32e40p_id_stage
 
     // Debug Signal
     .debug_mode_o                   ( debug_mode_o           ),
-    .debug_req_pending_o            ( debug_req_pending      ),
     .debug_cause_o                  ( debug_cause_o          ),
     .debug_csr_save_o               ( debug_csr_save_o       ),
     .debug_req_i                    ( debug_req_i            ),
@@ -1284,6 +1279,8 @@ module cv32e40p_id_stage
     .debug_ebreakm_i                ( debug_ebreakm_i        ),
     .debug_ebreaku_i                ( debug_ebreaku_i        ),
     .trigger_match_i                ( trigger_match_i        ),
+    .debug_p_elw_no_sleep_o         ( debug_p_elw_no_sleep_o ),
+    .debug_wfi_no_sleep_o           ( debug_wfi_no_sleep     ),
 
     // Wakeup Signal
     .wake_from_sleep_o              ( wake_from_sleep_o      ),

--- a/rtl/cv32e40p_load_store_unit.sv
+++ b/rtl/cv32e40p_load_store_unit.sv
@@ -48,6 +48,7 @@ module cv32e40p_load_store_unit
     input  logic [1:0]   data_type_ex_i,       // Data type word, halfword, byte    -> from ex stage
     input  logic [31:0]  data_wdata_ex_i,      // data to write to memory           -> from ex stage
     input  logic [1:0]   data_reg_offset_ex_i, // offset inside register for stores -> from ex stage
+    input  logic         data_load_event_ex_i, // load event                        -> from ex stage
     input  logic [1:0]   data_sign_ext_ex_i,   // sign extension                    -> from ex stage
 
     output logic [31:0]  data_rdata_ex_o,      // requested data                    -> to ex stage
@@ -61,6 +62,9 @@ module cv32e40p_load_store_unit
 
     input  logic [5:0]   data_atop_ex_i,       // atomic instructions signal        -> from ex stage
     output logic [5:0]   data_atop_o,          // atomic instruction signal         -> core output
+
+    output logic         p_elw_start_o,         // load event starts
+    output logic         p_elw_finish_o,        // load event finishes
 
     // stall signal
     output logic         lsu_ready_ex_o,       // LSU ready for new data in EX stage
@@ -100,6 +104,7 @@ module cv32e40p_load_store_unit
   logic [1:0]   rdata_offset_q;
   logic [1:0]   data_sign_ext_q;
   logic         data_we_q;
+  logic         data_load_event_q;
 
   logic [1:0]   wdata_offset;           // mux control for data to be written to memory
 
@@ -186,20 +191,25 @@ module cv32e40p_load_store_unit
   begin
     if(rst_n == 1'b0)
     begin
-      data_type_q     <= '0;
-      rdata_offset_q  <= '0;
-      data_sign_ext_q <= '0;
-      data_we_q       <= 1'b0;
+      data_type_q       <= '0;
+      rdata_offset_q    <= '0;
+      data_sign_ext_q   <= '0;
+      data_we_q         <= 1'b0;
+      data_load_event_q <= 1'b0;
     end
     else if (ctrl_update) // request was granted, we wait for rvalid and can continue to WB
     begin
-      data_type_q     <= data_type_ex_i;
-      rdata_offset_q  <= data_addr_int[1:0];
-      data_sign_ext_q <= data_sign_ext_ex_i;
-      data_we_q       <= data_we_ex_i;
+      data_type_q       <= data_type_ex_i;
+      rdata_offset_q    <= data_addr_int[1:0];
+      data_sign_ext_q   <= data_sign_ext_ex_i;
+      data_we_q         <= data_we_ex_i;
+      data_load_event_q <= data_load_event_ex_i;
     end
   end
 
+  // Load event starts when request is sent and finishes when (final) rvalid is received
+  assign p_elw_start_o = data_load_event_ex_i && data_req_o;
+  assign p_elw_finish_o = data_load_event_q && data_rvalid_i && !data_misaligned_ex_i;
 
   ////////////////////////////////////////////////////////////////////////
   //  ____  _               _____      _                 _              //

--- a/rtl/cv32e40p_sleep_unit.sv
+++ b/rtl/cv32e40p_sleep_unit.sv
@@ -1,0 +1,257 @@
+// Copyright 2020 Silicon Labs, Inc.
+//   
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//   
+//     https://solderpad.org/licenses/SHL-2.0/
+//   
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License 
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    Sleep Unit                                                 //
+// Project Name:   CV32E40P                                                   //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    Sleep unit containing the instantiated clock gate which    //
+//                 provides the clock (clk_o) for the rest of the design.     //
+//                                                                            //
+//                 The clock is gated for the following scenarios:            //
+//                                                                            //
+//                 - While waiting for fetch to become enabled                //
+//                 - While blocked on a WFI (PULP_CLUSTER = 0)                //
+//                 - While clock_en_i = 0 during a p.elw (PULP_CLUSTER = 1)   //
+//                                                                            //
+//                 Sleep is signaled via core_sleep_o when:                   //
+//                                                                            //
+//                 - During a p.elw (except in debug (i.e. pending debug      //
+//                   request, debug mode, single stepping, trigger match)     //
+//                 - During a WFI (except in debug)                           //
+//                                                                            //
+// Requirements:   If PULP_CLUSTER = 1 the environment must guarantee:        //
+//                                                                            //
+//                 - If core_sleep_o    == 1'b0, then pulp_clock_en_i == 1'b1 //
+//                 - If pulp_clock_en_i == 1'b0, then irq_i == 'b0            //
+//                 - If pulp_clock_en_i == 1'b0, then debug_req_i == 1'b0     //
+//                 - If pulp_clock_en_i == 1'b0, then instr_rvalid_i == 1'b0  //
+//                 - If pulp_clock_en_i == 1'b0, then instr_gnt_i == 1'b0     //
+//                 - If pulp_clock_en_i == 1'b0, then data_rvalid_i == 1'b0   //
+//                 - If pulp_clock_en_i == 1'b0, then data_gnt_i == 1'b1      //     
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40p_sleep_unit
+#(
+  parameter PULP_CLUSTER = 0
+)(
+  // Clock, reset interface
+  input  logic        clk_i,                    // Free running clock
+  input  logic        rst_n,
+  output logic        clk_o,                    // Gated clock
+  input  logic        scan_cg_en_i,             // Enable all clock gates for testing
+
+  // Core sleep
+  output logic        core_sleep_o,
+
+  // Fetch enable
+  input  logic        fetch_enable_i,
+  output logic        fetch_enable_o,
+
+  // Core status
+  input  logic        if_busy_i,
+  input  logic        ctrl_busy_i,
+  input  logic        lsu_busy_i,
+  input  logic        apu_busy_i,
+
+  // PULP Cluster interface
+  input  logic        pulp_clock_en_i,          // PULP clock enable (only used if PULP_CLUSTER = 1)
+  input  logic        p_elw_start_i,
+  input  logic        p_elw_finish_i,
+  input  logic        debug_p_elw_no_sleep_i,
+
+  // WFI wake
+  input  logic        wake_from_sleep_i
+);
+
+  import cv32e40p_defines::*;
+
+  logic              fetch_enable_q;            // Sticky version of fetch_enable_i
+  logic              fetch_enable_d;
+  logic              core_busy_q;               // Is core still busy (and requires a clock) with what needs to finish before entering sleep?
+  logic              core_busy_d;          
+  logic              p_elw_busy_q;              // Busy with p.elw (transaction in progress)?
+  logic              p_elw_busy_d;         
+  logic              clock_en;                  // Final clock enable
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Sleep FSM
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Make sticky version of fetch_enable_i
+  assign fetch_enable_d = fetch_enable_i ? 1'b1 : fetch_enable_q;
+
+  generate
+  if (PULP_CLUSTER) begin : PULP_SLEEP
+
+    // Busy unless in a p.elw and IF/APU are no longer busy
+    assign core_busy_d = p_elw_busy_d ? (if_busy_i || apu_busy_i) : 1'b1;
+
+     // Enable the clock only after the initial fetch enable while busy or instructed so by PULP Cluster's pulp_clock_en_i
+    assign clock_en = fetch_enable_q && (pulp_clock_en_i || core_busy_q);
+
+    // Sleep only in response to p.elw onec no longer busy (but not during various debug scenarios)
+    assign core_sleep_o = p_elw_busy_d && !core_busy_q && !debug_p_elw_no_sleep_i;
+
+    // p.elw is busy between load start and load finish (data_req_o / data_rvalid_i)
+    assign p_elw_busy_d = p_elw_start_i ? 1'b1 : (p_elw_finish_i ? 1'b0 : p_elw_busy_q);
+
+  end else begin : SLEEP
+
+    // Busy when any of the sub units is busy (typically wait for the instruction buffer to fill up)
+    assign core_busy_d = if_busy_i || ctrl_busy_i || lsu_busy_i || apu_busy_i;
+
+    // Enable the clock only after the initial fetch enable while busy or waking up to become busy
+    assign clock_en = fetch_enable_q && (wake_from_sleep_i || core_busy_q);
+
+    // Sleep only in response to WFI which leads to clock disable; debug_wfi_no_sleep_o in 
+    // cv32e40p_controller determines the scenarios for which WFI can(not) cause sleep.
+    assign core_sleep_o = fetch_enable_q && !clock_en;
+
+    // p.elw does not exist for PULP_CLUSTER = 0
+    assign p_elw_busy_d = 1'b0;
+
+  end
+  endgenerate
+
+  always_ff @(posedge clk_i, negedge rst_n)
+  begin
+    if (rst_n == 1'b0) begin
+      core_busy_q    <= 1'b0;
+      p_elw_busy_q   <= 1'b0;
+      fetch_enable_q <= 1'b0;
+    end else begin
+      core_busy_q    <= core_busy_d;
+      p_elw_busy_q   <= p_elw_busy_d;
+      fetch_enable_q <= fetch_enable_d;
+    end
+  end
+
+  // Fetch enable for Controller
+  assign fetch_enable_o = fetch_enable_q;
+
+  // Main clock gate of CV32E40P
+  cv32e40p_clock_gate core_clock_gate_i
+  (
+    .clk_i        ( clk_i           ),
+    .en_i         ( clock_en        ),
+    .scan_cg_en_i ( scan_cg_en_i    ),
+    .clk_o        ( clk_o           )
+  );
+
+  //----------------------------------------------------------------------------
+  // Assertions
+  //----------------------------------------------------------------------------
+
+`ifndef VERILATOR
+
+  // Clock gate is disabled during RESET state of the controller
+  property p_clock_en_0;
+     @(posedge clk_i) disable iff (!rst_n) ((id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::RESET) && (id_stage_i.controller_i.ctrl_fsm_ns == cv32e40p_defines::RESET)) |-> (clock_en == 1'b0);
+  endproperty
+
+  a_clock_en_0 : assert property(p_clock_en_0);
+
+  // Clock gate is enabled when exit from RESET state is required
+  property p_clock_en_1;
+     @(posedge clk_i) disable iff (!rst_n) ((id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::RESET) && (id_stage_i.controller_i.ctrl_fsm_ns != cv32e40p_defines::RESET)) |-> (clock_en == 1'b1);
+  endproperty
+
+  a_clock_en_1 : assert property(p_clock_en_1);
+
+  // Clock gate is not enabled before receiving fetch_enable_i pulse
+  property p_clock_en_2;
+     @(posedge clk_i) disable iff (!rst_n) (fetch_enable_q == 1'b0) |-> (clock_en == 1'b0);
+  endproperty
+
+  a_clock_en_2 : assert property(p_clock_en_2);
+
+  generate
+  if (PULP_CLUSTER) begin
+
+    // Clock gate is only possibly disabled in RESET or when PULP_CLUSTER disables clock
+    property p_clock_en_3;
+       @(posedge clk_i) disable iff (!rst_n) (clock_en == 1'b0) -> ((id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::RESET) || (PULP_CLUSTER && !pulp_clock_en_i));
+    endproperty
+
+    a_clock_en_3 : assert property(p_clock_en_3);
+
+    // Core can only sleep in response to p.elw
+    property p_only_sleep_during_p_elw;
+       @(posedge clk_i) disable iff (!rst_n) (core_sleep_o == 1'b1) |-> (p_elw_busy_d == 1'b1);
+    endproperty
+
+    a_only_sleep_during_p_elw : assert property(p_only_sleep_during_p_elw);
+
+
+    // Environment fully controls clock_en during sleep
+    property p_full_clock_en_control;
+       @(posedge clk_i) disable iff (!rst_n) (core_sleep_o == 1'b1) |-> (pulp_clock_en_i == clock_en);
+    endproperty
+
+    a_full_clock_en_control : assert property(p_full_clock_en_control);
+
+  end else begin
+
+    // Clock gate is only possibly disabled in RESET or SLEEP
+    property p_clock_en_4;
+       @(posedge clk_i) disable iff (!rst_n) (clock_en == 1'b0) -> ((id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::RESET) || (id_stage_i.controller_i.ctrl_fsm_ns == cv32e40p_defines::SLEEP));
+    endproperty
+
+    a_clock_en_4 : assert property(p_clock_en_4);
+
+    // Clock gate is enabled when exit from SLEEP state is required
+    property p_clock_en_5;
+       @(posedge clk_i) disable iff (!rst_n)  ((id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::SLEEP) && (id_stage_i.controller_i.ctrl_fsm_ns != cv32e40p_defines::SLEEP)) |-> (clock_en == 1'b1);
+    endproperty
+
+    a_clock_en_5 : assert property(p_clock_en_5);
+
+    // Core sleep is only signaled in SLEEP state
+    property p_core_sleep;
+       @(posedge clk_i) disable iff (!rst_n) (core_sleep_o == 1'b1) -> ((id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::SLEEP));
+    endproperty
+
+    a_core_sleep : assert property(p_core_sleep);
+
+    // Core can only become non-busy due to SLEEP entry
+    property p_non_busy;
+       @(posedge clk_i) disable iff (!rst_n) (core_busy_d == 1'b0) |-> (id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::WAIT_SLEEP) || (id_stage_i.controller_i.ctrl_fsm_cs == cv32e40p_defines::SLEEP);
+    endproperty
+
+    a_non_busy : assert property(p_non_busy);
+
+    // During (PULP_CLUSTER = 0) sleep it should be allowed to externally gate clk_i
+    property p_gate_clk_i;
+       @(posedge clk_i) disable iff (!rst_n) (core_sleep_o == 1'b1) |-> (core_busy_q == core_busy_d) && (p_elw_busy_q == p_elw_busy_d)&& (fetch_enable_q == fetch_enable_d);
+    endproperty
+
+    a_gate_clk_i : assert property(p_gate_clk_i);
+
+  end
+  endgenerate
+
+`endif
+
+endmodule // cv32e40p_sleep_unit

--- a/rtl/cv32e40p_tracer.sv
+++ b/rtl/cv32e40p_tracer.sv
@@ -39,7 +39,6 @@ module cv32e40p_tracer (
   input  logic        clk,
   input  logic        rst_n,
 
-  input  logic        fetch_enable,
   input  logic [31:0] hart_id_i,
 
   input  logic [31:0] pc,

--- a/src_files.yml
+++ b/src_files.yml
@@ -43,6 +43,7 @@ riscv:
     ./rtl/cv32e40p_prefetch_buffer.sv,
     ./rtl/cv32e40p_obi_interface.sv
     ./rtl/cv32e40p_prefetch_controller.sv
+    ./rtl/cv32e40p_sleep_unit.sv
     ./rtl/cv32e40p_core.sv,
     ./rtl/cv32e40p_apu_disp.sv,
     ./rtl/cv32e40p_fetch_fifo.sv,

--- a/tb/core/cv32e40p_wrapper.sv
+++ b/tb/core/cv32e40p_wrapper.sv
@@ -56,7 +56,7 @@ module cv32e40p_wrapper
     logic                         irq_external;
     logic [47:0]                  irq_fast;
 
-    logic                         core_busy_o;
+    logic                         core_sleep_o;
 
     assign debug_req_i = 1'b0;
 
@@ -73,7 +73,7 @@ module cv32e40p_wrapper
          .clk_i                  ( clk_i                 ),
          .rst_ni                 ( rst_ni                ),
 
-         .clock_en_i             ( 1'b1                  ),
+         .pulp_clock_en_i        ( 1'b1                  ),
          .scan_cg_en_i           ( 1'b0                  ),
 
          .boot_addr_i            ( BOOT_ADDR             ),
@@ -113,7 +113,7 @@ module cv32e40p_wrapper
          .debug_req_i            ( debug_req_i           ),
 
          .fetch_enable_i         ( fetch_enable_i        ),
-         .core_busy_o            ( core_busy_o           ));
+         .core_sleep_o           ( core_sleep_o           ));
 
     // this handles read to RAM and memory mapped pseudo peripherals
     mm_ram

--- a/tb/core/waves.tcl
+++ b/tb/core/waves.tcl
@@ -50,6 +50,8 @@ if {$rvcores ne ""} {
     add wave -group "IF Stage" -group "Hwlp Ctrl"            $rvcores/if_stage_i/HWLOOP_CONTROLLER/hwloop_controller_i/*
     add wave -group "ID Stage" -group "Hwloop Regs"          $rvcores/id_stage_i/HWLOOP_REGS/hwloop_regs_i/*
   }
+  add wave -group "Sleep Unit"                               $rvcores/sleep_unit_i/*
+
   add wave -group "IF Stage" -group "Prefetch" -group "CTRL" $rvcores/if_stage_i/prefetch_32/prefetch_buffer_i/prefetch_controller_i/*
   add wave -group "IF Stage" -group "Prefetch" -group "OBI"  $rvcores/if_stage_i/prefetch_32/prefetch_buffer_i/instruction_obi_i/*
 


### PR DESCRIPTION
Added/corrected sleep interface:

- Replacement of core_busy_o with core_sleep_o
- If PULP_CLUSTER = 0, then core_sleep_o can only become asserted in response to a WFI instruction
- If PULP_CLUSTER = 1, then core_sleep_o can only become asserted in response to a P.ELW instruction
- Keeping internal clock gated until fetch_enable_i sampled high
- Made WFI act as true NOP for PULP_CLUSTER = 1 (i.e. sleep state is never entered)
- Renamed clock_en_i to pulp_clock_en_i
- Made p.elw an illegal instruction for PULP_CLUSTER = 0
- Moved sleep related circuitry into its own file (cv32e40p_sleep_unit.sv)

Fixed issues: #373 #362 #379 

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>