### PR TITLE
add mtvec_addr_i port

### DIFF
--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -52,6 +52,7 @@ module cv32e40p_core
 
   // Core ID, Cluster ID, debug mode halt address and boot address are considered more or less static
   input  logic [31:0] boot_addr_i,
+  input  logic [31:0] mtvec_addr_i,
   input  logic [31:0] dm_halt_addr_i,
   input  logic [31:0] hart_id_i,
 
@@ -305,8 +306,8 @@ module cv32e40p_core
   logic [5:0]  csr_cause;
   logic        csr_restore_mret_id;
   logic        csr_restore_uret_id;
-
   logic        csr_restore_dret_id;
+  logic        csr_mtvec_init;
 
   // debug mode and dcsr configuration
   logic        debug_mode;
@@ -486,10 +487,10 @@ module cv32e40p_core
     .rst_n               ( rst_ni            ),
 
     // boot address
-    .boot_addr_i         ( boot_addr_i[31:1] ),
+    .boot_addr_i         ( boot_addr_i[31:0] ),
 
     // debug mode halt address
-    .dm_halt_addr_i      ( dm_halt_addr_i[31:2] ),
+    .dm_halt_addr_i      ( dm_halt_addr_i[31:0] ),
 
     // trap vector location
     .m_trap_base_addr_i  ( mtvec             ),
@@ -532,6 +533,7 @@ module cv32e40p_core
     .exc_pc_mux_i        ( exc_pc_mux_id     ),
     .m_exc_vec_pc_mux_i  ( m_exc_vec_pc_mux_id ),
     .u_exc_vec_pc_mux_i  ( u_exc_vec_pc_mux_id ),
+    .csr_mtvec_init_o    ( csr_mtvec_init    ),
 
     // from hwloop registers
     .hwlp_start_i        ( hwlp_start        ),
@@ -1012,8 +1014,9 @@ module cv32e40p_core
     .utvec_o                 ( utvec              ),
     .mtvec_mode_o            ( mtvec_mode         ),
     .utvec_mode_o            ( utvec_mode         ),
-    // boot address
-    .boot_addr_i             ( boot_addr_i[31:1]  ),
+    // mtvec address
+    .mtvec_addr_i            ( mtvec_addr_i[31:0] ),
+    .csr_mtvec_init_i        ( csr_mtvec_init     ),
     // Interface to CSRs (SRAM like)
     .csr_access_i            ( csr_access         ),
     .csr_addr_i              ( csr_addr           ),

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -61,8 +61,9 @@ module cv32e40p_cs_registers
   output logic  [1:0]     mtvec_mode_o,
   output logic  [1:0]     utvec_mode_o,
 
-  // Used for boot address
-  input  logic [30:0]     boot_addr_i,
+  // Used for mtvec address
+  input  logic [31:0]     mtvec_addr_i,
+  input  logic            csr_mtvec_init_i,
 
   // Interface to registers (SRAM like)
   input  logic                       csr_access_i,
@@ -624,7 +625,7 @@ if(PULP_SECURE==1) begin
     hwlp_regid_o             = '0;
     exception_pc             = pc_id_i;
     priv_lvl_n               = priv_lvl_q;
-    mtvec_n                  = mtvec_q;
+    mtvec_n                  = csr_mtvec_init_i ? mtvec_addr_i[31:8] : mtvec_q;
     utvec_n                  = utvec_q;
     mtvec_mode_n             = mtvec_mode_q;
     utvec_mode_n             = utvec_mode_q;
@@ -897,7 +898,7 @@ end else begin //PULP_SECURE == 0
     hwlp_regid_o             = '0;
     exception_pc             = pc_id_i;
     priv_lvl_n               = priv_lvl_q;
-    mtvec_n                  = mtvec_q;
+    mtvec_n                  = csr_mtvec_init_i ? mtvec_addr_i[31:8] : mtvec_q;
     utvec_n                  = '0;              // Not used if PULP_SECURE == 0
     pmp_reg_n.pmpaddr        = '0;              // Not used if PULP_SECURE == 0
     pmp_reg_n.pmpcfg_packed  = '0;              // Not used if PULP_SECURE == 0

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -45,10 +45,10 @@ module cv32e40p_if_stage
     input  logic [23:0] u_trap_base_addr_i,
     input  logic  [1:0] trap_addr_mux_i,
     // Boot address
-    input  logic [30:0] boot_addr_i,
+    input  logic [31:0] boot_addr_i,
 
     // Debug mode halt address
-    input  logic [29:0] dm_halt_addr_i,
+    input  logic [31:0] dm_halt_addr_i,
 
     // instruction request control
     input  logic        req_i,
@@ -85,6 +85,7 @@ module cv32e40p_if_stage
     input  logic  [2:0] exc_pc_mux_i,          // selects ISR address
     input  logic  [4:0] m_exc_vec_pc_mux_i,    // selects ISR address for vectorized interrupt lines
     input  logic  [4:0] u_exc_vec_pc_mux_i,    // selects ISR address for vectorized interrupt lines
+    output logic        csr_mtvec_init_o,      // tell CS regfile to init mtvec
 
     // jump and branch target and decision
     input  logic [31:0] jump_target_id_i,      // jump target address
@@ -151,7 +152,7 @@ module cv32e40p_if_stage
     unique case (exc_pc_mux_i)
       EXC_PC_EXCEPTION:                        exc_pc = { trap_base_addr, 8'h0 }; //1.10 all the exceptions go to base address
       EXC_PC_IRQ:                              exc_pc = { trap_base_addr, 1'b0, exc_vec_pc_mux, 2'b0 }; // interrupts are vectored
-      EXC_PC_DBD:                              exc_pc = { dm_halt_addr_i, 2'b0 };
+      EXC_PC_DBD:                              exc_pc = { dm_halt_addr_i[31:2], 2'b0 };
       default:                                 exc_pc = { trap_base_addr, 8'h0 };
     endcase
   end
@@ -162,7 +163,7 @@ module cv32e40p_if_stage
     fetch_addr_n = '0;
 
     unique case (pc_mux_i)
-      PC_BOOT:      fetch_addr_n = {boot_addr_i, 1'b0};
+      PC_BOOT:      fetch_addr_n = {boot_addr_i[31:2], 2'b0};
       PC_JUMP:      fetch_addr_n = jump_target_id_i;
       PC_BRANCH:    fetch_addr_n = jump_target_ex_i;
       PC_EXCEPTION: fetch_addr_n = exc_pc;             // set PC to exception handler
@@ -173,6 +174,9 @@ module cv32e40p_if_stage
       default:;
     endcase
   end
+
+  // tell CS register file to initialize mtvec on boot
+  assign csr_mtvec_init_o = (pc_mux_i == PC_BOOT) & pc_set_i;
 
   generate
     if (RDATA_WIDTH == 32) begin : prefetch_32


### PR DESCRIPTION
MTVEC will reset to mtvec_addr_i during first cycle of boot up.

Also made the boot_addr_i and dm_halt_addr_i ports consistent by passing whole vector ([31:0]) into submodules.

Fixes issue #401 

Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>