### PR TITLE
Conditionally compile tracer

### DIFF
--- a/bhv/cv32e40p_apu_tracer.sv
+++ b/bhv/cv32e40p_apu_tracer.sv
@@ -35,6 +35,8 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
+`ifdef CV32E40P_APU_TRACE
+
 module cv32e40p_apu_tracer
 (
 );
@@ -72,3 +74,5 @@ module cv32e40p_apu_tracer
      end
 
 endmodule // cv32e40p_apu_tracer
+
+`endif // CV32E40P_APU_TRACE

--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -22,6 +22,8 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
+`ifdef CV32E40P_TRACE_EXECUTION
+
 module cv32e40p_tracer import cv32e40p_pkg::*;
 (
   // Clock and Reset
@@ -1101,3 +1103,5 @@ module cv32e40p_tracer import cv32e40p_pkg::*;
   end // always @ (posedge clk)
 
 endmodule
+
+`endif // CV32E40P_TRACE_EXECUTION


### PR DESCRIPTION
A couple of conditionally compiler macros.  These are necessary for the CORE-V-VERIF `core` (verilator) testbench.