### PR TITLE
:recycle: removed deprecated condition in DBG_TAKEN_ID

### DIFF
--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -1170,7 +1170,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
         pc_set_o          = 1'b1;
         pc_mux_o          = PC_EXCEPTION;
         exc_pc_mux_o      = EXC_PC_DBD;
-        if (((debug_req_pending || trigger_match_i || debug_single_step_i) && (~debug_mode_q)) ||
+        if (((debug_req_pending || trigger_match_i) && (~debug_mode_q)) ||
             (ebrk_insn_i && ebrk_force_debug_mode && (~debug_mode_q))) begin
             csr_save_cause_o = 1'b1;
             csr_save_id_o    = 1'b1;
@@ -1181,8 +1181,6 @@ module cv32e40p_controller import cv32e40p_pkg::*;
                 debug_cause_o = DBG_CAUSE_EBREAK;
             if (trigger_match_i)
                 debug_cause_o = DBG_CAUSE_TRIGGER;
-            if (debug_single_step_i)
-                debug_cause_o = DBG_CAUSE_STEP;
         end
         ctrl_fsm_ns  = DECODE;
         debug_mode_n = 1'b1;


### PR DESCRIPTION
The DBG_TAKEN_ID is never used when single_step debug is active. This condition is from the time when the aligner was in the ID stage.