### PR TITLE
add a insn_compressed signal in the tracer that align with current retired instruction

### DIFF
--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -853,6 +853,7 @@ module cv32e40p_tracer import cv32e40p_pkg::*;
   // of making instr_trace_t visible to inspect it with your simulator. Some
   // choke for some unknown performance reasons.
   string insn_disas;
+  logic        insn_compressed;
   logic [31:0] insn_pc;
   logic [31:0] insn_val;
   reg_t insn_regs_write[$];
@@ -875,7 +876,8 @@ module cv32e40p_tracer import cv32e40p_pkg::*;
             trace.regs_write[i].value = wb_reg_wdata;
       end while (!wb_valid);
 
-      insn_disas = trace.str;
+      insn_disas      = trace.str;
+      insn_compressed = trace.compressed;
       trace.printInstrTrace();
       insn_pc    = trace.pc;
       insn_val   = trace.instr;


### PR DESCRIPTION

as hint to the functional coverage that the instruction was originally compressed

This is fastest route to fixing issues with current RV32ISA functional coverage model.  

Long term we should make some structural changes to the tracer such that it properly reflects the ISA-level instructions entering the pipeline.  I will open a separate issue to track that.

