### PR TITLE
remove the reserved irq assumption for core verification

### DIFF
--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -1149,14 +1149,6 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
   // Assumptions
   //----------------------------------------------------------------------------
 
-  // Assume that IRQ indices which are reserved by the RISC-V privileged spec
-  // or are meant for User or Hypervisor mode are not used (i.e. tied to 0)
-  property p_no_reserved_irq;
-     @(posedge clk_i) disable iff (!rst_ni) (1'b1) |-> ((irq_i & ~IRQ_MASK) == 'b0);
-  endproperty
-
-  a_no_reserved_irq : assume property(p_no_reserved_irq);
-
   generate
   if (PULP_CLUSTER) begin
 


### PR DESCRIPTION
the assume should be reintroduced in a bind file for core integrators

I want to be able to ensure that toggling reserved irqs does not alter any internal core functionality in core UVM testbenches

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>