### PR TITLE
Fix Todo : concern about illegal insn for dret call in non debug mode

### DIFF
--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -1094,7 +1094,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
           end
           dret_dec_i: begin
               //dret
-              //TODO: is illegal when not in debug mode
+              // this case is only reachable while in debug_mode
               pc_mux_o              = PC_DRET;
               pc_set_o              = 1'b1;
               debug_mode_n          = 1'b0;


### PR DESCRIPTION
Fixes one TODO in the RTL based on issue #430

Concern was raised in a TODO comment if the core is in XRET_JUMP state and `dret `is called should result in an illegal exception if not in debug mode. Previous state, FLUSH_EX and FLUSH_WB will ensure `dret `call while not in debug_mode will invoke an illegal exception, preventing XRET_JUMP state and `dret `and !debug_mode.

Proven with temporary modification to debug_test as well as temporary formal check:

```
  a_xret_jump_dret_shall_be_debug_mode : assert property
  (
   @(posedge clk) (ctrl_fsm_cs==XRET_JUMP) && dret_dec_i |-> debug_mode_q
   ) ;

```
![image](https://user-images.githubusercontent.com/59703134/93934128-48ab0080-fce8-11ea-9a3c-709bdcfefc0d.png)


Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>