### PR TITLE
Fix Todo: remove comment flush ex

### DIFF
--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -646,7 +646,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
 
                         illegal_insn_i | ecall_insn_i:
                         begin
-                            ctrl_fsm_ns = FLUSH_EX; // TODO: flush ex
+                            ctrl_fsm_ns = FLUSH_EX;
                         end
 
                         (~ebrk_force_debug_mode & ebrk_insn_i):
@@ -821,7 +821,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
 
                         illegal_insn_i | ecall_insn_i:
                         begin
-                            ctrl_fsm_ns = FLUSH_EX; // TODO: flush ex
+                            ctrl_fsm_ns = FLUSH_EX;
                         end
 
                         (~ebrk_force_debug_mode & ebrk_insn_i):


### PR DESCRIPTION
Fixes two TODOs in the cv32e40p_controller.sv RTL based on issue #430

The comment is not clear. The code is written correctly whereby an illegal instruction or ecall instruction will enter the FLUSH_EX state while running in single-step mode.

@bluewww , Can you please review this PR as you may have entered this TODO comment on a previous change:
https://github.com/openhwgroup/cv32e40p/commit/efc02fc77cf250d3c2c618ae406ca6cbe0689e7e#diff-f8105fd1c66cefe40c50f701d9f3108eR565


Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>