### PR TITLE
Fix Todo: remove TODO comment regarding csr save action during USER mode

### DIFF
--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -847,7 +847,6 @@ if(PULP_SECURE==1) begin
               mstatus_n.mpie = mstatus_q.uie;
               mstatus_n.mie  = 1'b0;
               mstatus_n.mpp  = PRIV_LVL_U;
-              // TODO: correctly handled?
               if (debug_csr_save_i)
                   depc_n = exception_pc;
               else
@@ -861,7 +860,6 @@ if(PULP_SECURE==1) begin
                 priv_lvl_n     = PRIV_LVL_U;
                 mstatus_n.upie = mstatus_q.uie;
                 mstatus_n.uie  = 1'b0;
-                // TODO: correctly handled?
                 if (debug_csr_save_i)
                     depc_n = exception_pc;
                 else
@@ -874,7 +872,6 @@ if(PULP_SECURE==1) begin
                 mstatus_n.mpie = mstatus_q.uie;
                 mstatus_n.mie  = 1'b0;
                 mstatus_n.mpp  = PRIV_LVL_U;
-                // TODO: correctly handled?
                 if (debug_csr_save_i)
                     depc_n = exception_pc;
                 else


### PR DESCRIPTION
Fixes three TODOs in the cv32e40p_cs_registers.sv RTL based on issue #430

The comment is a reminder to check that the depc, mepc, and other csr status registers are properly implemented when a csr_save_cause event occurs (irq, exception, debug) while in USER mode. There are several existing issues regarding improper behavior around this piece of code that will not be fixed on CV32E40**P**, and are labeled with WAIVED:CV32E40**P**.
 I propose (with this PR) to remove the TODO comments and rely on these outstanding issues to resolve this USER mode code once the USER mode feature is added to the CV32E40.

Issues include:
#132 #140 #157 #182 #306 



Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>