### PR TITLE
Fix Todo: remove TODO comment to re-locate code

### DIFF
--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -2886,7 +2886,6 @@ module cv32e40p_decoder import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*;
     end
 
     // misaligned access was detected by the LSU
-    // TODO: this section should eventually be moved out of the decoder
     if (data_misaligned_i == 1'b1)
     begin
       // only part of the pipeline is unstalled, make sure that the


### PR DESCRIPTION
Fixes TODO in the cv32e40p_decoder.sv RTL based on issue #430

Todo comment suggests moving a piece of code out of decoder. Code has been there for 5 years and seems relevant to alu operation based on data_misalignment.

@atraber , Can you please review and see if the TODO comment is OK to be removed. The comment was added with this change:
https://github.com/openhwgroup/cv32e40p/commit/9858caff47a4213d0222ee19290db88facd6be6a

Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>