### PR TITLE
Fix Todo: Remove Todo comments in id_stage.sv

### DIFF
--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -506,7 +506,6 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   // clipping immediate, uses a small barrel shifter to pre-process the
   // immediate and an adder to subtract 1
   // The end result is a mask that has 1's set in the lower part
-  // TODO: check if this can be shared with the bit-manipulation unit
   assign imm_clip_type    = (32'h1 << instr[24:20]) - 1;
 
   //-----------------------------------------------------------------------------
@@ -634,8 +633,6 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   //////////////////////////////////////////////////////
 
   // Immediate Mux for operand B
-  // TODO: check if sign-extension stuff works well here, maybe able to save
-  // some area here
   always_comb begin : immediate_b_mux
     unique case (imm_b_mux_sel)
       IMMB_I:      imm_b = imm_i_type;


### PR DESCRIPTION
Remove two TODOs in the cv32e40p_id_stage.sv RTL based on issue #430

Both TODO comments added by @atraber , 5 years back.

The first comment refers to optimizing the code to possibly reuse bit-manipulation logic to perform the custom clipping for XPULP instructions. At this stage, this level of optimization is not needed.

The second comment refers to optimizing immediate_b_mux sign extension, most likely applying to the custom XPULP instruction formats. 

@atraber, Please review this PR to remove those comments.

Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>