### PR TITLE
pd replaced by constraints file only

### DIFF
--- a/pd/README.md
+++ b/pd/README.md
@@ -1,3 +1,0 @@
-## Physical Design files for the CV32E40P
-This directory exists to contain the Makefiles, scripts, constraints, etc. for
-the physical design flow for CV32E40P.   At this time is primarly synthesis scripts.


### PR DESCRIPTION
Removed 'pd' dir since we now have 'constraints' dir with sdc file.

@davideschiavone I will close https://github.com/openhwgroup/cv32e40p/pull/273 and https://github.com/openhwgroup/cv32e40p/pull/305 as well unless you indicate a good reason to keep those.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>