### PR TITLE
Added debug status pins; fix for #563

### DIFF
--- a/bhv/cv32e40p_wrapper.sv
+++ b/bhv/cv32e40p_wrapper.sv
@@ -85,7 +85,9 @@ module cv32e40p_wrapper import cv32e40p_apu_core_pkg::*;
 
   // Debug Interface
   input  logic        debug_req_i,
-
+  output logic        debug_havereset_o,
+  output logic        debug_running_o,
+  output logic        debug_halted_o,
 
   // CPU Control Signals
   input  logic        fetch_enable_i,

--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -137,6 +137,9 @@ module cv32e40p_controller import cv32e40p_pkg::*;
   input  logic         trigger_match_i,
   output logic         debug_p_elw_no_sleep_o,
   output logic         debug_wfi_no_sleep_o,
+  output logic         debug_havereset_o,
+  output logic         debug_running_o,
+  output logic         debug_halted_o,
 
   // Wakeup Signal
   output logic        wake_from_sleep_o,
@@ -202,6 +205,8 @@ module cv32e40p_controller import cv32e40p_pkg::*;
   // FSM state encoding
   ctrl_state_e ctrl_fsm_cs, ctrl_fsm_ns;
 
+  // Debug state
+  debug_state_e debug_fsm_cs, debug_fsm_ns;
 
   logic jump_done, jump_done_q, jump_in_dec, branch_in_id_dec, branch_in_id;
 
@@ -1463,6 +1468,59 @@ endgenerate
       else if( debug_mode_q )
         debug_req_q <= 1'b0;
 
+  // Debug state FSM
+  always_ff @(posedge clk , negedge rst_n)
+  begin
+    if ( rst_n == 1'b0 )
+    begin
+      debug_fsm_cs <= HAVERESET;
+    end
+    else
+    begin
+      debug_fsm_cs <= debug_fsm_ns;
+    end
+  end
+
+  always_comb
+  begin
+    debug_fsm_ns = debug_fsm_cs;
+
+    case (debug_fsm_cs)
+      HAVERESET:
+      begin
+        if (debug_mode_n || (ctrl_fsm_ns == FIRST_FETCH)) begin
+          if (debug_mode_n) begin
+            debug_fsm_ns = HALTED;
+          end else begin
+            debug_fsm_ns = RUNNING;
+          end
+        end
+      end
+
+      RUNNING:
+      begin
+        if (debug_mode_n) begin
+          debug_fsm_ns = HALTED;
+        end
+      end
+
+      HALTED:
+      begin
+        if (!debug_mode_n) begin
+          debug_fsm_ns = RUNNING;
+        end
+      end
+
+      default: begin
+        debug_fsm_ns = HAVERESET;
+      end
+    endcase
+  end
+
+  assign debug_havereset_o = debug_fsm_cs[0];
+  assign debug_running_o = debug_fsm_cs[1];
+  assign debug_halted_o = debug_fsm_cs[2];
+
   //----------------------------------------------------------------------------
   // Assertions
   //----------------------------------------------------------------------------
@@ -1516,12 +1574,19 @@ endgenerate
   endgenerate
 
   // Ensure DBG_TAKEN_IF can only be enterred if in single step mode or woken
- // up from sleep by debug_req_i
+  // up from sleep by debug_req_i
          
   a_single_step_dbg_taken_if : assert property (@(posedge clk)  disable iff (!rst_n)  (ctrl_fsm_ns==DBG_TAKEN_IF) |-> ((~debug_mode_q && debug_single_step_i) || debug_force_wakeup_n));
 
   // Ensure DBG_FLUSH state is only one cycle. This implies that cause is either trigger, debug_req_entry, or ebreak
   a_dbg_flush : assert property (@(posedge clk)  disable iff (!rst_n)  (ctrl_fsm_cs==DBG_FLUSH) |-> (ctrl_fsm_ns!=DBG_FLUSH) );
+
+
+  // Ensure that debug state outputs are one-hot
+  a_debug_state_onehot : assert property (@(posedge clk) disable iff (!rst_n) (1'b1) |-> $onehot({debug_havereset_o, debug_running_o, debug_halted_o}));
+
+  // Ensure that debug_halted_o equals debug_mode_q
+  a_debug_halted_equals_debug_mode : assert property (@(posedge clk) disable iff (!rst_n) (1'b1) |-> (debug_mode_q == debug_halted_o));
 
 `endif
 

--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -1517,9 +1517,9 @@ endgenerate
     endcase
   end
 
-  assign debug_havereset_o = debug_fsm_cs[0];
-  assign debug_running_o = debug_fsm_cs[1];
-  assign debug_halted_o = debug_fsm_cs[2];
+  assign debug_havereset_o = debug_fsm_cs[HAVERESET_INDEX];
+  assign debug_running_o = debug_fsm_cs[RUNNING_INDEX];
+  assign debug_halted_o = debug_fsm_cs[HALTED_INDEX];
 
   //----------------------------------------------------------------------------
   // Assertions
@@ -1581,9 +1581,8 @@ endgenerate
   // Ensure DBG_FLUSH state is only one cycle. This implies that cause is either trigger, debug_req_entry, or ebreak
   a_dbg_flush : assert property (@(posedge clk)  disable iff (!rst_n)  (ctrl_fsm_cs==DBG_FLUSH) |-> (ctrl_fsm_ns!=DBG_FLUSH) );
 
-
   // Ensure that debug state outputs are one-hot
-  a_debug_state_onehot : assert property (@(posedge clk) disable iff (!rst_n) (1'b1) |-> $onehot({debug_havereset_o, debug_running_o, debug_halted_o}));
+  a_debug_state_onehot : assert property (@(posedge clk) $onehot({debug_havereset_o, debug_running_o, debug_halted_o}));
 
   // Ensure that debug_halted_o equals debug_mode_q
   a_debug_halted_equals_debug_mode : assert property (@(posedge clk) disable iff (!rst_n) (1'b1) |-> (debug_mode_q == debug_halted_o));

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -88,7 +88,9 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
 
   // Debug Interface
   input  logic        debug_req_i,
-
+  output logic        debug_havereset_o,
+  output logic        debug_running_o,
+  output logic        debug_halted_o,
 
   // CPU Control Signals
   input  logic        fetch_enable_i,
@@ -698,6 +700,9 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
     .debug_cause_o                ( debug_cause          ),
     .debug_csr_save_o             ( debug_csr_save       ),
     .debug_req_i                  ( debug_req_i          ),
+    .debug_havereset_o            ( debug_havereset_o    ),
+    .debug_running_o              ( debug_running_o      ),
+    .debug_halted_o               ( debug_halted_o       ),
     .debug_single_step_i          ( debug_single_step    ),
     .debug_ebreakm_i              ( debug_ebreakm        ),
     .debug_ebreaku_i              ( debug_ebreaku        ),

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -214,6 +214,9 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
     input  logic        debug_ebreaku_i,
     input  logic        trigger_match_i,
     output logic        debug_p_elw_no_sleep_o,
+    output logic        debug_havereset_o,
+    output logic        debug_running_o,
+    output logic        debug_halted_o,
 
     // Wakeup Signal
     output logic        wake_from_sleep_o,
@@ -1187,6 +1190,9 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
     .trigger_match_i                ( trigger_match_i        ),
     .debug_p_elw_no_sleep_o         ( debug_p_elw_no_sleep_o ),
     .debug_wfi_no_sleep_o           ( debug_wfi_no_sleep     ),
+    .debug_havereset_o              ( debug_havereset_o      ),
+    .debug_running_o                ( debug_running_o        ),
+    .debug_halted_o                 ( debug_halted_o         ),
 
     // Wakeup Signal
     .wake_from_sleep_o              ( wake_from_sleep_o      ),

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -176,11 +176,13 @@ parameter VEC_MODE16 = 2'b10;
 parameter VEC_MODE8  = 2'b11;
 
 
-  // FSM state encoding
-  typedef enum  logic [4:0] { RESET, BOOT_SET, SLEEP, WAIT_SLEEP, FIRST_FETCH,
-                      DECODE, IRQ_FLUSH_ELW, ELW_EXE, FLUSH_EX, FLUSH_WB, XRET_JUMP,
-                      DBG_TAKEN_ID, DBG_TAKEN_IF, DBG_FLUSH, DBG_WAIT_BRANCH, DECODE_HWLOOP } ctrl_state_e;
+// FSM state encoding
+typedef enum logic [4:0] { RESET, BOOT_SET, SLEEP, WAIT_SLEEP, FIRST_FETCH,
+                   DECODE, IRQ_FLUSH_ELW, ELW_EXE, FLUSH_EX, FLUSH_WB, XRET_JUMP,
+                   DBG_TAKEN_ID, DBG_TAKEN_IF, DBG_FLUSH, DBG_WAIT_BRANCH, DECODE_HWLOOP } ctrl_state_e;
 
+// Debug FSM state encoding
+typedef enum  logic [2:0] { HAVERESET = 3'b001, RUNNING = 3'b010, HALTED  = 3'b100 } debug_state_e;
 
 /////////////////////////////////////////////////////////
 //    ____ ____    ____            _     _             //

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -182,7 +182,14 @@ typedef enum logic [4:0] { RESET, BOOT_SET, SLEEP, WAIT_SLEEP, FIRST_FETCH,
                    DBG_TAKEN_ID, DBG_TAKEN_IF, DBG_FLUSH, DBG_WAIT_BRANCH, DECODE_HWLOOP } ctrl_state_e;
 
 // Debug FSM state encoding
-typedef enum  logic [2:0] { HAVERESET = 3'b001, RUNNING = 3'b010, HALTED  = 3'b100 } debug_state_e;
+// State encoding done one-hot to ensure that debug_havereset_o, debug_running_o, debug_halted_o
+// will come directly from flip-flops. *_INDEX and debug_state_e encoding must match
+
+parameter HAVERESET_INDEX = 0;
+parameter RUNNING_INDEX = 1;
+parameter HALTED_INDEX = 2;
+
+typedef enum logic [2:0] { HAVERESET = 3'b001, RUNNING = 3'b010, HALTED = 3'b100 } debug_state_e;
 
 /////////////////////////////////////////////////////////
 //    ____ ____    ____            _     _             //


### PR DESCRIPTION
Fixes #563 

- Example waveforms showing the behavior of the added signals (to be added in documentation for CV32E40P):
- debug_halted_o has been shown to be equivalent to debug_mode_q (assertion is present in RTL)

![image](https://user-images.githubusercontent.com/40633348/97904036-3b018580-1d40-11eb-87c6-8760e421ea12.png)

![image](https://user-images.githubusercontent.com/40633348/97904089-4bb1fb80-1d40-11eb-9d58-26ac27e666a6.png)


Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>