### PR TITLE
Silabs oysteink tracer trigger ebreak

### DIFF
--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -45,6 +45,7 @@ module cv32e40p_tracer
   input  logic        id_valid,
   input  logic        is_decoding,
   input  logic        is_illegal,
+  input  logic        trigger_match,
 
   input  logic [31:0] rs1_value,
   input  logic [31:0] rs2_value,
@@ -396,7 +397,7 @@ module cv32e40p_tracer
     if (id_valid && is_decoding && !is_illegal) 
       trace_new = 1;
     // Create a new EBREAK instruuction (will bypass pipeline execution)
-    else if (is_decoding && ebrk_insn && (ebrk_force_debug_mode || debug_mode))
+    else if (is_decoding && !trigger_match && ebrk_insn && (ebrk_force_debug_mode || debug_mode))
       trace_new_ebreak = 1;
 
     // Instruction remains in the pipeline for one more cycle if misaligned

--- a/bhv/cv32e40p_wrapper.sv
+++ b/bhv/cv32e40p_wrapper.sv
@@ -147,6 +147,7 @@ module cv32e40p_wrapper import cv32e40p_apu_core_pkg::*;
       .id_valid       ( core_i.id_stage_i.id_valid_o                ),
       .is_decoding    ( core_i.id_stage_i.is_decoding_o             ),
       .is_illegal     ( core_i.id_stage_i.illegal_insn_dec          ),
+      .trigger_match  ( core_i.id_stage_i.trigger_match_i           ),
       .rs1_value      ( core_i.id_stage_i.operand_a_fw_id           ),
       .rs2_value      ( core_i.id_stage_i.operand_b_fw_id           ),
       .rs3_value      ( core_i.id_stage_i.alu_operand_c             ),


### PR DESCRIPTION
Small update to the tracer to allow ebreak instructions at a trigger address to not retire. Otherwise, the tracer retires the ebreak which gives a miscompare when running with the ISS.