### PR TITLE
Added explicit names to generated blocks

### DIFF
--- a/rtl/cv32e40p_alu.sv
+++ b/rtl/cv32e40p_alu.sv
@@ -61,7 +61,7 @@ module cv32e40p_alu import cv32e40p_pkg::*;
   generate
     genvar k;
     for(k = 0; k < 32; k++)
-    begin
+    begin : gen_operand_a_rev
       assign operand_a_rev[k] = operand_a_i[31-k];
     end
   endgenerate
@@ -70,7 +70,7 @@ module cv32e40p_alu import cv32e40p_pkg::*;
   generate
     genvar m;
     for(m = 0; m < 32; m++)
-    begin
+    begin : gen_operand_a_neg_rev
       assign operand_a_neg_rev[m] = operand_a_neg[31-m];
     end
   endgenerate
@@ -290,7 +290,7 @@ module cv32e40p_alu import cv32e40p_pkg::*;
   genvar       j;
   generate
     for(j = 0; j < 32; j++)
-    begin
+    begin : gen_shift_left_result
       assign shift_left_result[j] = shift_right_result[31-j];
     end
   endgenerate
@@ -361,7 +361,7 @@ module cv32e40p_alu import cv32e40p_pkg::*;
   genvar i;
   generate
     for(i = 0; i < 4; i++)
-    begin
+    begin : gen_is_vec
       assign is_equal_vec[i]   = (operand_a_i[8*i+7:8*i] == operand_b_i[8*i+7:i*8]);
       assign is_greater_vec[i] = $signed({operand_a_i[8*i+7] & cmp_signed[i], operand_a_i[8*i+7:8*i]})
                                   >
@@ -856,17 +856,17 @@ module cv32e40p_alu import cv32e40p_pkg::*;
   generate
     // radix-2 bit reverse
     for(j = 0; j < 32; j++)
-    begin
+    begin : gen_radix_2_rev
       assign radix_2_rev[j] = shift_result[31-j];
     end
     // radix-4 bit reverse
     for(j = 0; j < 16; j++)
-    begin
+    begin : gen_radix_4_rev
       assign radix_4_rev[2*j+1:2*j] = shift_result[31-j*2:31-j*2-1];
     end
     // radix-8 bit reverse
     for(j = 0; j < 10; j++)
-    begin
+    begin : gen_radix_8_rev
       assign radix_8_rev[3*j+2:3*j] = shift_result[31-j*3:31-j*3-2];
     end
     assign radix_8_rev[31:30] = 2'b0;

--- a/rtl/cv32e40p_alu_div.sv
+++ b/rtl/cv32e40p_alu_div.sv
@@ -89,7 +89,7 @@ module cv32e40p_alu_div
   genvar index;
   generate
       for(index = 0; index < C_WIDTH; index++ )
-      begin : bit_swapping
+      begin : gen_bit_swapping
           assign ResReg_DP_rev[index] = ResReg_DP[C_WIDTH-1-index];
       end
   endgenerate

--- a/rtl/cv32e40p_apu_disp.sv
+++ b/rtl/cv32e40p_apu_disp.sv
@@ -164,7 +164,7 @@ module cv32e40p_apu_disp (
   //
   // There is a dependency if the register is equal to one of the instructions
   generate
-    for (genvar i = 0; i < 3; i++) begin
+    for (genvar i = 0; i < 3; i++) begin : gen_read_deps
       assign read_deps_req[i]      = (read_regs_i[i] == addr_req)      & read_regs_valid_i[i];
       assign read_deps_inflight[i] = (read_regs_i[i] == addr_inflight) & read_regs_valid_i[i];
       assign read_deps_waiting[i]  = (read_regs_i[i] == addr_waiting)  & read_regs_valid_i[i];
@@ -172,7 +172,7 @@ module cv32e40p_apu_disp (
   endgenerate
 
   generate
-    for (genvar i = 0; i < 2; i++) begin
+    for (genvar i = 0; i < 2; i++) begin : gen_write_deps
       assign write_deps_req[i]      = (write_regs_i[i] == addr_req)      & write_regs_valid_i[i];
       assign write_deps_inflight[i] = (write_regs_i[i] == addr_inflight) & write_regs_valid_i[i];
       assign write_deps_waiting[i]  = (write_regs_i[i] == addr_waiting)  & write_regs_valid_i[i];

--- a/rtl/cv32e40p_compressed_decoder.sv
+++ b/rtl/cv32e40p_compressed_decoder.sv
@@ -45,7 +45,6 @@ module cv32e40p_compressed_decoder
   //  \____\___/|_| |_| |_| .__/|_|  \___||___/___/\___|\__,_| |____/ \___|\___\___/ \__,_|\___|_|    //
   //                      |_|                                                                         //
   //////////////////////////////////////////////////////////////////////////////////////////////////////
-  generate
 
   always_comb
   begin
@@ -326,8 +325,6 @@ module cv32e40p_compressed_decoder
       end
     endcase
   end
-
-  endgenerate
 
   assign is_compressed_o = (instr_i[1:0] != 2'b11);
 

--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -1252,7 +1252,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
 
 
 generate
-  if(PULP_XPULP) begin
+  if(PULP_XPULP) begin : gen_hwlp
     //////////////////////////////////////////////////////////////////////////////
     // Convert hwlp_jump_o to a pulse
     //////////////////////////////////////////////////////////////////////////////
@@ -1286,7 +1286,7 @@ generate
     assign hwlp_end1_geq_pc        = hwlp_end_addr_i[1] >= pc_id_i;
     assign is_hwlp_body            = ((hwlp_start0_leq_pc && hwlp_end0_geq_pc) && hwlp_counter0_gt_1) ||  ((hwlp_start1_leq_pc && hwlp_end1_geq_pc) && hwlp_counter1_gt_1);
 
-  end else begin
+  end else begin : gen_no_hwlp
 
     assign hwlp_jump_o             = 1'b0;
     assign hwlp_end_4_id_q         = 1'b0;
@@ -1547,7 +1547,7 @@ endgenerate
   a_pulp_cluster_excluded_states : assert property(p_pulp_cluster_excluded_states);
 
   generate
-  if (PULP_XPULP) begin
+  if (PULP_XPULP) begin : gen_pulp_xpulp_assertions
 
     // HWLoop 0 and 1 having target address constraints
     property p_hwlp_same_target_address;
@@ -1556,7 +1556,7 @@ endgenerate
 
     a_hwlp_same_target_address : assert property(p_hwlp_same_target_address) else $warning("%t, HWLoops target address do not respect constraints", $time);
 
-  end else begin
+  end else begin : gen_no_pulp_xpulp_assertions
 
     property p_no_hwlp;
        @(posedge clk) (1'b1) |-> ((pc_mux_o != PC_HWLOOP) && (ctrl_fsm_cs != DECODE_HWLOOP) &&

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -1071,7 +1071,7 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
   ///////////////////////////
 
   generate
-  if(PULP_SECURE && USE_PMP) begin : RISCY_PMP
+  if(PULP_SECURE && USE_PMP) begin : gen_pmp
   cv32e40p_pmp
   #(
      .N_PMP_ENTRIES(N_PMP_ENTRIES)
@@ -1107,7 +1107,7 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
     .instr_addr_o            ( instr_addr_o       ),
     .instr_err_o             ( instr_err_pmp      )
   );
-  end else begin
+  end else begin : gen_no_pmp
     assign instr_req_o   = instr_req_pmp;
     assign instr_addr_o  = instr_addr_pmp;
     assign instr_gnt_pmp = instr_gnt_i;
@@ -1127,7 +1127,7 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
   //----------------------------------------------------------------------------
 
   generate
-  if (PULP_CLUSTER) begin
+  if (PULP_CLUSTER) begin : gen_pulp_cluster_assumptions
 
     // Assumptions/requirements on the environment when pulp_clock_en_i = 0
     property p_env_req_0;
@@ -1170,7 +1170,7 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
   end
 
   generate
-  if (!PULP_CLUSTER) begin
+  if (!PULP_CLUSTER) begin : gen_no_pulp_cluster_assertions
     // Check that a taken IRQ is actually enabled (e.g. that we do not react to an IRQ that was just disabled in MIE)
     property p_irq_enabled_0;
        @(posedge clk) disable iff (!rst_ni) (pc_set && (pc_mux_id == PC_EXCEPTION) && (exc_pc_mux_id == EXC_PC_IRQ)) |->
@@ -1190,7 +1190,7 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
   endgenerate
 
   generate
-  if (!PULP_XPULP) begin
+  if (!PULP_XPULP) begin : gen_no_pulp_xpulp_assertions
 
     // Illegal, ECALL, EBRK checks excluded for PULP due to other definition for for Hardware Loop
 

--- a/rtl/cv32e40p_ex_stage.sv
+++ b/rtl/cv32e40p_ex_stage.sv
@@ -307,7 +307,7 @@ module cv32e40p_ex_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   );
 
    generate
-      if (FPU == 1) begin
+      if (FPU == 1) begin : gen_apu
          ////////////////////////////////////////////////////
          //     _    ____  _   _   ____ ___ ____  ____     //
          //    / \  |  _ \| | | | |  _ \_ _/ ___||  _ \    //
@@ -363,7 +363,7 @@ module cv32e40p_ex_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
          assign apu_result      = apu_result_i;
          assign fpu_fflags_we_o = apu_valid;
       end
-      else begin
+      else begin : gen_no_apu
          // default assignements for the case when no FPU/APU is attached.
          assign apu_req_o         = '0;
          assign apu_operands_o[0] = '0;

--- a/rtl/cv32e40p_ff_one.sv
+++ b/rtl/cv32e40p_ff_one.sv
@@ -46,7 +46,7 @@ module cv32e40p_ff_one
 
   generate
     genvar j;
-    for (j = 0; j < LEN; j++) begin
+    for (j = 0; j < LEN; j++) begin : gen_index_lut
       assign index_lut[j] = $unsigned(j);
     end
   endgenerate
@@ -55,30 +55,30 @@ module cv32e40p_ff_one
     genvar k;
     genvar l;
     genvar level;
-    for (level = 0; level < NUM_LEVELS; level++) begin
+    for (level = 0; level < NUM_LEVELS; level++) begin : gen_tree
     //------------------------------------------------------------
-    if (level < NUM_LEVELS-1) begin
-      for (l = 0; l < 2**level; l++) begin
+    if (level < NUM_LEVELS-1) begin : gen_non_root_level
+      for (l = 0; l < 2**level; l++) begin : gen_node
         assign sel_nodes[2**level-1+l]   = sel_nodes[2**(level+1)-1+l*2] | sel_nodes[2**(level+1)-1+l*2+1];
         assign index_nodes[2**level-1+l] = (sel_nodes[2**(level+1)-1+l*2] == 1'b1) ?
                                            index_nodes[2**(level+1)-1+l*2] : index_nodes[2**(level+1)-1+l*2+1];
       end
     end
     //------------------------------------------------------------
-    if (level == NUM_LEVELS-1) begin
-      for (k = 0; k < 2**level; k++) begin
+    if (level == NUM_LEVELS-1) begin : gen_root_level
+      for (k = 0; k < 2**level; k++) begin : gen_node
         // if two successive indices are still in the vector...
-        if (k * 2 < LEN-1) begin
+        if (k * 2 < LEN-1) begin : gen_two
           assign sel_nodes[2**level-1+k]   = in_i[k*2] | in_i[k*2+1];
           assign index_nodes[2**level-1+k] = (in_i[k*2] == 1'b1) ? index_lut[k*2] : index_lut[k*2+1];
         end
         // if only the first index is still in the vector...
-        if (k * 2 == LEN-1) begin
+        if (k * 2 == LEN-1) begin: gen_one
           assign sel_nodes[2**level-1+k]   = in_i[k*2];
           assign index_nodes[2**level-1+k] = index_lut[k*2];
         end
         // if index is out of range
-        if (k * 2 > LEN-1) begin
+        if (k * 2 > LEN-1) begin : gen_out_of_range
           assign sel_nodes[2**level-1+k]   = 1'b0;
           assign index_nodes[2**level-1+k] = '0;
         end

--- a/rtl/cv32e40p_fifo.sv
+++ b/rtl/cv32e40p_fifo.sv
@@ -49,14 +49,16 @@ module cv32e40p_fifo #(
 
     assign cnt_o = status_cnt_q;
 
-    if (DEPTH == 0) begin
-        assign empty_o     = ~push_i;
-        assign full_o      = ~pop_i;
-    end else begin
-        assign full_o       = (status_cnt_q == FIFO_DEPTH[ADDR_DEPTH:0]);
-        assign empty_o      = (status_cnt_q == 0) & ~(FALL_THROUGH & push_i);
-    end
     // status flags
+    generate
+      if (DEPTH == 0) begin : gen_zero_depth
+          assign empty_o     = ~push_i;
+          assign full_o      = ~pop_i;
+      end else begin : gen_non_zero_depth
+          assign full_o       = (status_cnt_q == FIFO_DEPTH[ADDR_DEPTH:0]);
+          assign empty_o      = (status_cnt_q == 0) & ~(FALL_THROUGH & push_i);
+      end
+    endgenerate
 
     // read and write queue logic
     always_comb begin : read_write_comb

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -787,7 +787,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   /////////////////////////////
   // read regs
   generate
-    if (APU == 1) begin : apu_op_preparation
+    if (APU == 1) begin : gen_apu
 
       if (APU_NARGS_CPU >= 1)
        assign apu_operands[0] = alu_operand_a;
@@ -869,8 +869,8 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
 
       assign apu_write_regs_o         = apu_write_regs;
       assign apu_write_regs_valid_o   = apu_write_regs_valid;
-    end else begin
-      for (genvar i=0; i<APU_NARGS_CPU; i++) begin : apu_tie_off
+    end else begin : gen_no_apu
+      for (genvar i=0; i<APU_NARGS_CPU; i++) begin : gen_apu_tie_off
         assign apu_operands[i]       = '0;
       end
 
@@ -1296,7 +1296,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   );
 
   generate
-  if (PULP_XPULP) begin : HWLOOP_REGS
+  if (PULP_XPULP) begin : gen_hwloop_regs
 
     ///////////////////////////////////////////////
     //  _   ___        ___     ___   ___  ____   //
@@ -1382,9 +1382,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
       assign hwlp_regid = (|hwlp_we_masked) ? hwlp_regid_int : csr_hwlp_regid_i;
       assign hwlp_we    = (|hwlp_we_masked) ? hwlp_we_masked : csr_hwlp_we_i;
 
-
-
-  end else begin
+  end else begin: gen_no_hwloop_regs
 
     assign hwlp_start_o   = 'b0;
     assign hwlp_end_o     = 'b0;
@@ -1402,7 +1400,6 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
     assign hwlp_we        = 'b0;
 
   end
-
   endgenerate
 
 
@@ -1738,7 +1735,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
     a_xret_csr : assert property(p_xret_csr);
 
     generate
-    if (!A_EXTENSION) begin
+    if (!A_EXTENSION) begin : gen_no_a_extension_assertions
 
       // Check that A extension opcodes are decoded as illegal when A extension not enabled
       property p_illegal_0;
@@ -1751,7 +1748,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
     endgenerate
 
     generate
-    if (!PULP_XPULP) begin
+    if (!PULP_XPULP) begin : gen_no_pulp_xpulp_assertions
 
       // Check that PULP extension opcodes are decoded as illegal when PULP extension is not enabled
       property p_illegal_1;

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -302,7 +302,7 @@ module cv32e40p_if_stage
 `ifdef CV32E40P_ASSERT_ON
 
   generate
-  if (!PULP_XPULP) begin
+  if (!PULP_XPULP) begin : gen_no_pulp_xpulp_assertions
 
     // Check that PC Mux cannot select Hardware Loop address iF PULP extensions are not included
     property p_pc_mux_0;
@@ -315,7 +315,7 @@ module cv32e40p_if_stage
   endgenerate
 
  generate
-  if (!PULP_SECURE) begin
+  if (!PULP_SECURE) begin : gen_no_pulp_secure_assertions
 
     // Check that PC Mux cannot select URET address if User Mode is not included
     property p_pc_mux_1;

--- a/rtl/cv32e40p_int_controller.sv
+++ b/rtl/cv32e40p_int_controller.sv
@@ -77,10 +77,13 @@ module cv32e40p_int_controller import cv32e40p_pkg::*;
   assign irq_wu_ctrl_o = |(irq_i & mie_bypass_i);
 
   // Global interrupt enable
-if (PULP_SECURE)
-  assign global_irq_enable = ((u_ie_i || irq_sec_i) && current_priv_lvl_i == PRIV_LVL_U) || (m_ie_i && current_priv_lvl_i == PRIV_LVL_M);
-else
-  assign global_irq_enable = m_ie_i;
+  generate
+    if (PULP_SECURE) begin : gen_pulp_secure
+      assign global_irq_enable = ((u_ie_i || irq_sec_i) && current_priv_lvl_i == PRIV_LVL_U) || (m_ie_i && current_priv_lvl_i == PRIV_LVL_M);
+    end else begin : gen_no_pulp_secure
+      assign global_irq_enable = m_ie_i;
+    end
+  endgenerate
 
   // Request to take interrupt if there is a locally enabled interrupt while interrupts are also enabled globally
   assign irq_req_ctrl_o = (|irq_local_qual) && global_irq_enable;

--- a/rtl/cv32e40p_load_store_unit.sv
+++ b/rtl/cv32e40p_load_store_unit.sv
@@ -419,12 +419,12 @@ module cv32e40p_load_store_unit
 
   // Transaction request generation
   generate
-    if (PULP_OBI == 0) begin
+    if (PULP_OBI == 0) begin : gen_no_pulp_obi
       // OBI compatible (avoids combinatorial path from data_rvalid_i to data_req_o).
       // Multiple trans_* transactions can be issued (and accepted) before a response
       // (resp_*) is received.
       assign trans_valid = data_req_ex_i && (cnt_q < DEPTH);
-    end else begin
+    end else begin : gen_pulp_obi
       // Legacy PULP OBI behavior, i.e. only issue subsequent transaction if preceding transfer
       // is about to finish (re-introducing timing critical path from data_rvalid_i to data_req_o)
       assign trans_valid = (cnt_q == 2'b00) ? data_req_ex_i && (cnt_q < DEPTH) :

--- a/rtl/cv32e40p_obi_interface.sv
+++ b/rtl/cv32e40p_obi_interface.sv
@@ -90,7 +90,7 @@ module cv32e40p_obi_interface
   //////////////////////////////////////////////////////////////////////////////
 
   generate
-  if (TRANS_STABLE) begin : TRANSACTION_STABILITY
+  if (TRANS_STABLE) begin : gen_trans_stable
 
     // If the incoming transaction itself is stable, then it satisfies the OBI protocol
     // and signals can be passed to/from OBI directly.
@@ -106,7 +106,7 @@ module cv32e40p_obi_interface
     // FSM not used
     assign state_q = TRANSPARENT;
     assign next_state = TRANSPARENT;
-  end else begin
+  end else begin : gen_no_trans_stable
 
     // OBI A channel registers (to keep A channel stable)
     logic [31:0]        obi_addr_q;

--- a/rtl/cv32e40p_pmp.sv
+++ b/rtl/cv32e40p_pmp.sv
@@ -170,14 +170,14 @@ module cv32e40p_pmp import cv32e40p_pkg::*;
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    generate
       for(i=0;i<N_PMP_ENTRIES;i++)
-      begin : CFG_EXP
+      begin : gen_cfg_exp
          assign {LOCK_rule[i],WIRI_rule[i],MODE_rule[i],X_rule[i], W_rule[i], R_rule[i] } = pmp_cfg_i[i];
       end
 
       // address Expansion
 
       for(i=0;i<N_PMP_ENTRIES;i++)
-      begin : ADDR_EXP
+      begin : gen_addr_exp
          always @(*)
          begin
             start_addr[i] = '0;

--- a/rtl/cv32e40p_popcnt.sv
+++ b/rtl/cv32e40p_popcnt.sv
@@ -35,25 +35,25 @@ module cv32e40p_popcnt
 
   genvar      l, m, n, p;
   generate for(l = 0; l < 16; l++)
-    begin
+    begin : gen_cnt_l1
       assign cnt_l1[l] = {1'b0, in_i[2*l]} + {1'b0, in_i[2*l + 1]};
     end
   endgenerate
 
   generate for(m = 0; m < 8; m++)
-    begin
+    begin : gen_cnt_l2
       assign cnt_l2[m] = {1'b0, cnt_l1[2*m]} + {1'b0, cnt_l1[2*m + 1]};
     end
   endgenerate
 
   generate for(n = 0; n < 4; n++)
-    begin
+    begin : gen_cnt_l3
       assign cnt_l3[n] = {1'b0, cnt_l2[2*n]} + {1'b0, cnt_l2[2*n + 1]};
     end
   endgenerate
 
   generate for(p = 0; p < 2; p++)
-    begin
+    begin : gen_cnt_l4
       assign cnt_l4[p] = {1'b0, cnt_l3[2*p]} + {1'b0, cnt_l3[2*p + 1]};
     end
   endgenerate

--- a/rtl/cv32e40p_prefetch_controller.sv
+++ b/rtl/cv32e40p_prefetch_controller.sv
@@ -138,12 +138,12 @@ module cv32e40p_prefetch_controller
 
   // Transaction request generation
   generate
-    if (PULP_OBI == 0) begin
+    if (PULP_OBI == 0) begin : gen_no_pulp_obi
       // OBI compatible (avoids combinatorial path from instr_rvalid_i to instr_req_o).
       // Multiple trans_* transactions can be issued (and accepted) before a response
       // (resp_*) is received.
       assign trans_valid_o = req_i && (fifo_cnt_masked + cnt_q < DEPTH);
-    end else begin
+    end else begin : gen_pulp_obi
       // Legacy PULP OBI behavior, i.e. only issue subsequent transaction if preceding transfer
       // is about to finish (re-introducing timing critical path from instr_rvalid_i to instr_req_o)
       assign trans_valid_o = (cnt_q == 3'b000) ? req_i && (fifo_cnt_masked + cnt_q < DEPTH) :
@@ -243,7 +243,7 @@ module cv32e40p_prefetch_controller
   end
 
   generate
-  if (PULP_XPULP) begin
+  if (PULP_XPULP) begin : gen_hwlp
 
     // Flush the FIFO if it is not empty and we are hwlp branching.
     // If HWLP_END is not going to ID, save it from the flush.
@@ -299,7 +299,7 @@ module cv32e40p_prefetch_controller
     // is served first so the flush should be normal (caused by branch_i)
     assign hwlp_flush_resp_delayed = hwlp_flush_after_resp && resp_valid_i;
 
-  end else begin
+  end else begin : gen_no_hwlp
 
     // Flush the FIFO if it is not empty
     assign fifo_flush_o             = branch_i;

--- a/rtl/cv32e40p_register_file_latch.sv
+++ b/rtl/cv32e40p_register_file_latch.sv
@@ -147,35 +147,21 @@ module cv32e40p_register_file
    assign waddr_a = waddr_a_i;
    assign waddr_b = waddr_b_i;
 
-    always_comb
-       begin : p_WADa
-          for(i = 1; i < NUM_TOT_WORDS; i++)
-            begin : p_WordItera
-               if ( (we_a_i == 1'b1 ) && (waddr_a == i) )
-                 waddr_onehot_a[i] = 1'b1;
-               else
-                 waddr_onehot_a[i] = 1'b0;
-            end
-       end
-
-     always_comb
-       begin : p_WADb
-          for(j = 1; j < NUM_TOT_WORDS; j++)
-            begin : p_WordIterb
-               if ( (we_b_i == 1'b1 ) && (waddr_b == j) )
-                 waddr_onehot_b[j] = 1'b1;
-               else
-                 waddr_onehot_b[j] = 1'b0;
-            end
-       end
+   genvar gidx;
+   generate
+     for (gidx=1; gidx<NUM_TOT_WORDS; gidx++) begin : gen_we_decoder
+       assign waddr_onehot_a[gidx] = (we_a_i == 1'b1 ) && (waddr_a == gidx);
+       assign waddr_onehot_b[gidx] = (we_b_i == 1'b1 ) && (waddr_b == gidx);
+     end
+   endgenerate
 
    //-----------------------------------------------------------------------------
    //-- WRITE : Clock gating (if integrated clock-gating cells are available)
    //-----------------------------------------------------------------------------
    generate
       for(x = 1; x < NUM_TOT_WORDS; x++)
-        begin : CG_CELL_WORD_ITER
-             cv32e40p_clock_gate CG_Inst
+        begin : gen_clock_gate
+             cv32e40p_clock_gate clock_gate_i
              (
               .clk_i        ( clk_int                               ),
               .en_i         ( waddr_onehot_a[x] | waddr_onehot_b[x] ),

--- a/rtl/cv32e40p_sleep_unit.sv
+++ b/rtl/cv32e40p_sleep_unit.sv
@@ -104,7 +104,7 @@ module cv32e40p_sleep_unit
   assign fetch_enable_d = fetch_enable_i ? 1'b1 : fetch_enable_q;
 
   generate
-  if (PULP_CLUSTER) begin : PULP_SLEEP
+  if (PULP_CLUSTER) begin : g_pulp_sleep
 
     // Busy unless in a p.elw and IF/APU are no longer busy
     assign core_busy_d = p_elw_busy_d ? (if_busy_i || apu_busy_i) : 1'b1;
@@ -118,7 +118,7 @@ module cv32e40p_sleep_unit
     // p.elw is busy between load start and load finish (data_req_o / data_rvalid_i)
     assign p_elw_busy_d = p_elw_start_i ? 1'b1 : (p_elw_finish_i ? 1'b0 : p_elw_busy_q);
 
-  end else begin : NO_PULP_SLEEP
+  end else begin : g_no_pulp_sleep
 
     // Busy when any of the sub units is busy (typically wait for the instruction buffer to fill up)
     assign core_busy_d = if_busy_i || ctrl_busy_i || lsu_busy_i || apu_busy_i;
@@ -189,7 +189,7 @@ module cv32e40p_sleep_unit
   a_clock_en_2 : assert property(p_clock_en_2);
 
   generate
-  if (PULP_CLUSTER) begin
+  if (PULP_CLUSTER) begin : g_pulp_cluster_assertions
 
     // Clock gate is only possibly disabled in RESET or when PULP_CLUSTER disables clock
     property p_clock_en_3;
@@ -213,7 +213,7 @@ module cv32e40p_sleep_unit
 
     a_full_clock_en_control : assert property(p_full_clock_en_control);
 
-  end else begin
+  end else begin : g_no_pulp_cluster_assertions
 
     // Clock gate is only possibly disabled in RESET or SLEEP
     property p_clock_en_4;

--- a/sva/cv32e40p_prefetch_controller_sva.sv
+++ b/sva/cv32e40p_prefetch_controller_sva.sv
@@ -100,7 +100,7 @@ module cv32e40p_prefetch_controller_sva
                            cnt_q, DEPTH, count_up, count_down))
 
   generate
-  if (PULP_XPULP) begin
+  if (PULP_XPULP) begin : gen_pulp_xpulp_assertions
     // When HWLP_END-4 is in ID and we are hwlp branching,
     // HWLP_END should at least have already been granted
     // by the OBI interface
@@ -114,7 +114,7 @@ module cv32e40p_prefetch_controller_sva
         `uvm_error("Prefetch Controller SVA",
                    $sformatf("Hardware Loop End should already be granted"))
 
-  end else begin
+  end else begin : gen_no_pulp_xpulp_assertions
 
     property p_hwlp_not_used;
        @(posedge clk) disable iff (!rst_n) (1'b1) |-> ((hwlp_jump_i == 1'b0) && (hwlp_target_i == 32'b0) && (hwlp_wait_resp_flush == 1'b0) &&


### PR DESCRIPTION
Hi @strichmo Can you please have a look and let me know if you agree with the naming style. I tried to give all generated blocks a gen_ prefixed name.

The code is sequentially equivalent to the original code (had to rewrite some code in register file and CSR file to get proper block naming).

Reason for the gen_ prefixing is to have constant names that can be used in waivers, code coverage, etc.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>