### PR TITLE
:bug: fix trigger function of random interrupt generator

### DIFF
--- a/example_tb/core/cv32e40p_random_interrupt_generator.sv
+++ b/example_tb/core/cv32e40p_random_interrupt_generator.sv
@@ -243,14 +243,6 @@ begin
 
   // build irq monitor word
   irq_pc_trig_lines.irq_software = 1'b1;
-
-  // irq monitor word: update logic
-  while(~irq_lines_changed) begin
-    @(posedge clk_i);
-    irq_lines <= irq_lines_i;
-  end
-
-  irq_pc_trig_lines.irq_software = irq_lines_i [3];
   irq_pc_trig_lines.irq_timer    = irq_lines_i [7];
   irq_pc_trig_lines.irq_external = irq_lines_i [11];
   irq_pc_trig_lines.irq_fast     = irq_lines_i [31:16];


### PR DESCRIPTION
Just removing wrong code in random interrupt generator that was preventing it to trigger interrupts on a given program counter