### PR TITLE
:art: changing to enumerator for alu opcodes

### DIFF
--- a/rtl/cv32e40p_alu.sv
+++ b/rtl/cv32e40p_alu.sv
@@ -30,7 +30,7 @@ module cv32e40p_alu import cv32e40p_pkg::*;
   input  logic                     clk,
   input  logic                     rst_n,
   input  logic                     enable_i,
-  input  logic [ALU_OP_WIDTH-1:0]  operator_i,
+  input  alu_opcode_e              operator_i,
   input  logic [31:0]              operand_a_i,
   input  logic [31:0]              operand_b_i,
   input  logic [31:0]              operand_c_i,

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -180,7 +180,7 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
   logic [ 1:0] alu_clpx_shift_ex;
 
   // Multiplier Control
-  logic [ 2:0] mult_operator_ex;
+  mul_opcode_e mult_operator_ex;
   logic [31:0] mult_operand_a_ex;
   logic [31:0] mult_operand_b_ex;
   logic [31:0] mult_operand_c_ex;
@@ -237,12 +237,12 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
 
   // CSR control
   logic        csr_access_ex;
-  logic [1:0]  csr_op_ex;
+  csr_opcode_e csr_op_ex;
   logic [23:0] mtvec, utvec;
   logic [1:0]  mtvec_mode;
   logic [1:0]  utvec_mode;
 
-  logic [1:0]  csr_op;
+  csr_opcode_e csr_op;
   csr_num_e    csr_addr;
   csr_num_e    csr_addr_int;
   logic [31:0] csr_rdata;

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -168,7 +168,7 @@ module cv32e40p_core import cv32e40p_apu_core_pkg::*;
 
   // ALU Control
   logic        alu_en_ex;
-  logic [ALU_OP_WIDTH-1:0] alu_operator_ex;
+  alu_opcode_e alu_operator_ex;
   logic [31:0] alu_operand_a_ex;
   logic [31:0] alu_operand_b_ex;
   logic [31:0] alu_operand_c_ex;

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -59,10 +59,10 @@ module cv32e40p_cs_registers import cv32e40p_pkg::*;
   input  logic            csr_mtvec_init_i,
 
   // Interface to registers (SRAM like)
-  input  csr_num_e                   csr_addr_i,
-  input  logic [31:0]                csr_wdata_i,
-  input  logic  [1:0]                csr_op_i,
-  output logic [31:0]                csr_rdata_o,
+  input  csr_num_e        csr_addr_i,
+  input  logic [31:0]     csr_wdata_i,
+  input  csr_opcode_e     csr_op_i,
+  output logic [31:0]     csr_rdata_o,
 
   output logic [2:0]         frm_o,
   input  logic [C_FFLAG-1:0] fflags_i,
@@ -1473,7 +1473,7 @@ end //PULP_SECURE
         end else if( (wcnt_gidx>2) && (wcnt_gidx<(NUM_MHPMCOUNTERS+3))) begin : gen_mhpmcounter
           // add +1 if any event is enabled and active
           assign mhpmcounter_write_increment[wcnt_gidx] = !mhpmcounter_write_lower[wcnt_gidx] &&
-                                                          !mhpmcounter_write_upper[wcnt_gidx] && 
+                                                          !mhpmcounter_write_upper[wcnt_gidx] &&
                                                           !mcountinhibit_q[wcnt_gidx] &&
                                                           |(hpm_events & mhpmevent_q[wcnt_gidx][NUM_HPM_EVENTS-1:0]);
         end else begin : gen_mhpmcounter_not_implemented
@@ -1482,7 +1482,7 @@ end //PULP_SECURE
       end else begin : gen_pulp_perf_counters
         // PULP PERF COUNTERS share all events in one register (not compliant with RISC-V)
         assign mhpmcounter_write_increment[wcnt_gidx] = !mhpmcounter_write_lower[wcnt_gidx] &&
-                                                        !mhpmcounter_write_upper[wcnt_gidx] && 
+                                                        !mhpmcounter_write_upper[wcnt_gidx] &&
                                                         !mcountinhibit_q[wcnt_gidx] &&
                                                         |(hpm_events & mhpmevent_q[wcnt_gidx][NUM_HPM_EVENTS-1:0]);
       end

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -90,7 +90,7 @@ module cv32e40p_decoder import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*;
   output logic        is_subrot_o,
 
   // MUL related control signals
-  output logic [2:0]  mult_operator_o,         // Multiplication operation selection
+  output mul_opcode_e mult_operator_o,         // Multiplication operation selection
   output logic        mult_int_en_o,           // perform integer multiplication
   output logic        mult_dot_en_o,           // perform dot multiplication
   output logic [0:0]  mult_imm_mux_o,          // Multiplication immediate mux selector
@@ -120,7 +120,7 @@ module cv32e40p_decoder import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*;
   // CSR manipulation
   output logic        csr_access_o,            // access to CSR
   output logic        csr_status_o,            // access to xstatus CSR
-  output logic [1:0]  csr_op_o,                // operation to perform on CSR
+  output csr_opcode_e csr_op_o,                // operation to perform on CSR
   input  PrivLvl_t    current_priv_lvl_i,      // The current privilege level
 
   // LD/ST unit signals
@@ -161,7 +161,7 @@ module cv32e40p_decoder import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*;
   logic       csr_illegal;
   logic [1:0] ctrl_transfer_insn;
 
-  logic [1:0] csr_op;
+  csr_opcode_e csr_op;
 
   logic       alu_en;
   logic       mult_int_en;

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -76,7 +76,7 @@ module cv32e40p_decoder import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*;
 
   // ALU signals
   output logic        alu_en_o,                // ALU enable
-  output logic [ALU_OP_WIDTH-1:0] alu_operator_o, // ALU operation selection
+  output alu_opcode_e alu_operator_o, // ALU operation selection
   output logic [2:0]  alu_op_a_mux_sel_o,      // operand a selection: reg value, PC, immediate or zero
   output logic [2:0]  alu_op_b_mux_sel_o,      // operand b selection: reg value or immediate
   output logic [1:0]  alu_op_c_mux_sel_o,      // operand c selection: reg value or jump target

--- a/rtl/cv32e40p_ex_stage.sv
+++ b/rtl/cv32e40p_ex_stage.sv
@@ -56,7 +56,7 @@ module cv32e40p_ex_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   input  logic [ 1:0] alu_clpx_shift_i,
 
   // Multiplier signals
-  input  logic [ 2:0] mult_operator_i,
+  input  mul_opcode_e mult_operator_i,
   input  logic [31:0] mult_operand_a_i,
   input  logic [31:0] mult_operand_b_i,
   input  logic [31:0] mult_operand_c_i,

--- a/rtl/cv32e40p_ex_stage.sv
+++ b/rtl/cv32e40p_ex_stage.sv
@@ -42,7 +42,7 @@ module cv32e40p_ex_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   input  logic        rst_n,
 
   // ALU signals from ID stage
-  input  logic [ALU_OP_WIDTH-1:0] alu_operator_i,
+  input  alu_opcode_e alu_operator_i,
   input  logic [31:0] alu_operand_a_i,
   input  logic [31:0] alu_operand_b_i,
   input  logic [31:0] alu_operand_c_i,

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -109,7 +109,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
 
     // ALU
     output logic        alu_en_ex_o,
-    output logic [ALU_OP_WIDTH-1:0] alu_operator_ex_o,
+    output alu_opcode_e alu_operator_ex_o,
     output logic        alu_is_clpx_ex_o,
     output logic        alu_is_subrot_ex_o,
     output logic [ 1:0] alu_clpx_shift_ex_o,
@@ -350,7 +350,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
 
   // ALU Control
   logic        alu_en;
-  logic [ALU_OP_WIDTH-1:0] alu_operator;
+  alu_opcode_e alu_operator;
   logic [2:0]  alu_op_a_mux_sel;
   logic [2:0]  alu_op_b_mux_sel;
   logic [1:0]  alu_op_c_mux_sel;

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -115,14 +115,14 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
     output logic [ 1:0] alu_clpx_shift_ex_o,
 
     // MUL
-    output logic [ 2:0] mult_operator_ex_o,
-    output logic [31:0] mult_operand_a_ex_o,
-    output logic [31:0] mult_operand_b_ex_o,
-    output logic [31:0] mult_operand_c_ex_o,
-    output logic        mult_en_ex_o,
-    output logic        mult_sel_subword_ex_o,
-    output logic [ 1:0] mult_signed_mode_ex_o,
-    output logic [ 4:0] mult_imm_ex_o,
+    output mul_opcode_e  mult_operator_ex_o,
+    output logic [31:0]  mult_operand_a_ex_o,
+    output logic [31:0]  mult_operand_b_ex_o,
+    output logic [31:0]  mult_operand_c_ex_o,
+    output logic         mult_en_ex_o,
+    output logic         mult_sel_subword_ex_o,
+    output logic [ 1:0]  mult_signed_mode_ex_o,
+    output logic [ 4:0]  mult_imm_ex_o,
 
     output logic [31:0] mult_dot_op_a_ex_o,
     output logic [31:0] mult_dot_op_b_ex_o,
@@ -152,7 +152,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
 
     // CSR ID/EX
     output logic        csr_access_ex_o,
-    output logic [1:0]  csr_op_ex_o,
+    output csr_opcode_e csr_op_ex_o,
     input  PrivLvl_t    current_priv_lvl_i,
     output logic        csr_irq_sec_o,
     output logic [5:0]  csr_cause_o,
@@ -361,7 +361,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
   logic [1:0]  ctrl_transfer_target_mux_sel;
 
   // Multiplier Control
-  logic [2:0]  mult_operator;    // multiplication operation selection
+  mul_opcode_e mult_operator;    // multiplication operation selection
   logic        mult_en;          // multiplication is used instead of ALU
   logic        mult_int_en;      // use integer multiplier
   logic        mult_sel_subword; // Select a subword when doing multiplications
@@ -421,7 +421,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
 
   // CSR control
   logic        csr_access;
-  logic [1:0]  csr_op;
+  csr_opcode_e csr_op;
   logic        csr_status;
 
   logic        prepost_useincr;
@@ -1429,7 +1429,7 @@ module cv32e40p_id_stage import cv32e40p_pkg::*; import cv32e40p_apu_core_pkg::*
       alu_is_clpx_ex_o            <= 1'b0;
       alu_is_subrot_ex_o          <= 1'b0;
 
-      mult_operator_ex_o          <= '0;
+      mult_operator_ex_o          <= MUL_MAC32;
       mult_operand_a_ex_o         <= '0;
       mult_operand_b_ex_o         <= '0;
       mult_operand_c_ex_o         <= '0;

--- a/rtl/cv32e40p_mult.sv
+++ b/rtl/cv32e40p_mult.sv
@@ -23,13 +23,13 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-module cv32e40p_mult
+module cv32e40p_mult import cv32e40p_pkg::*;
 (
   input  logic        clk,
   input  logic        rst_n,
 
   input  logic        enable_i,
-  input  logic [ 2:0] operator_i,
+  input  mul_opcode_e operator_i,
 
   // integer and short multiplier
   input  logic        short_subword_i,

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -167,13 +167,20 @@ typedef enum logic [ALU_OP_WIDTH-1:0]
 
 } alu_opcode_e;
 
-parameter MUL_MAC32 = 3'b000;
-parameter MUL_MSU32 = 3'b001;
-parameter MUL_I     = 3'b010;
-parameter MUL_IR    = 3'b011;
-parameter MUL_DOT8  = 3'b100;
-parameter MUL_DOT16 = 3'b101;
-parameter MUL_H     = 3'b110;
+parameter MUL_OP_WIDTH = 3;
+
+typedef enum logic [MUL_OP_WIDTH-1:0]
+{
+
+ MUL_MAC32 = 3'b000,
+ MUL_MSU32 = 3'b001,
+ MUL_I     = 3'b010,
+ MUL_IR    = 3'b011,
+ MUL_DOT8  = 3'b100,
+ MUL_DOT16 = 3'b101,
+ MUL_H     = 3'b110
+
+ } mul_opcode_e;
 
 // vector modes
 parameter VEC_MODE32 = 2'b00;
@@ -474,10 +481,16 @@ typedef enum logic[11:0] {
 } csr_num_e;
 
 // CSR operations
-parameter CSR_OP_READ  = 2'b00;
-parameter CSR_OP_WRITE = 2'b01;
-parameter CSR_OP_SET   = 2'b10;
-parameter CSR_OP_CLEAR = 2'b11;
+
+parameter CSR_OP_WIDTH = 2;
+
+typedef enum logic [CSR_OP_WIDTH-1:0]
+{
+ CSR_OP_READ  = 2'b00,
+ CSR_OP_WRITE = 2'b01,
+ CSR_OP_SET   = 2'b10,
+ CSR_OP_CLEAR = 2'b11
+} csr_opcode_e;
 
 // CSR interrupt pending/enable bits
 parameter int unsigned CSR_MSIX_BIT      = 3;

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -82,85 +82,90 @@ parameter REGC_ZERO = 2'b11;
 
 parameter ALU_OP_WIDTH = 7;
 
-parameter ALU_ADD   = 7'b0011000;
-parameter ALU_SUB   = 7'b0011001;
-parameter ALU_ADDU  = 7'b0011010;
-parameter ALU_SUBU  = 7'b0011011;
-parameter ALU_ADDR  = 7'b0011100;
-parameter ALU_SUBR  = 7'b0011101;
-parameter ALU_ADDUR = 7'b0011110;
-parameter ALU_SUBUR = 7'b0011111;
+typedef enum logic [ALU_OP_WIDTH-1:0]
+{
 
-parameter ALU_XOR   = 7'b0101111;
-parameter ALU_OR    = 7'b0101110;
-parameter ALU_AND   = 7'b0010101;
+ ALU_ADD   = 7'b0011000,
+ ALU_SUB   = 7'b0011001,
+ ALU_ADDU  = 7'b0011010,
+ ALU_SUBU  = 7'b0011011,
+ ALU_ADDR  = 7'b0011100,
+ ALU_SUBR  = 7'b0011101,
+ ALU_ADDUR = 7'b0011110,
+ ALU_SUBUR = 7'b0011111,
+
+ ALU_XOR   = 7'b0101111,
+ ALU_OR    = 7'b0101110,
+ ALU_AND   = 7'b0010101,
 
 // Shifts
-parameter ALU_SRA   = 7'b0100100;
-parameter ALU_SRL   = 7'b0100101;
-parameter ALU_ROR   = 7'b0100110;
-parameter ALU_SLL   = 7'b0100111;
+ ALU_SRA   = 7'b0100100,
+ ALU_SRL   = 7'b0100101,
+ ALU_ROR   = 7'b0100110,
+ ALU_SLL   = 7'b0100111,
 
 // bit manipulation
-parameter ALU_BEXT  = 7'b0101000;
-parameter ALU_BEXTU = 7'b0101001;
-parameter ALU_BINS  = 7'b0101010;
-parameter ALU_BCLR  = 7'b0101011;
-parameter ALU_BSET  = 7'b0101100;
-parameter ALU_BREV  = 7'b1001001;
+ ALU_BEXT  = 7'b0101000,
+ ALU_BEXTU = 7'b0101001,
+ ALU_BINS  = 7'b0101010,
+ ALU_BCLR  = 7'b0101011,
+ ALU_BSET  = 7'b0101100,
+ ALU_BREV  = 7'b1001001,
 
 // Bit counting
-parameter ALU_FF1   = 7'b0110110;
-parameter ALU_FL1   = 7'b0110111;
-parameter ALU_CNT   = 7'b0110100;
-parameter ALU_CLB   = 7'b0110101;
+ ALU_FF1   = 7'b0110110,
+ ALU_FL1   = 7'b0110111,
+ ALU_CNT   = 7'b0110100,
+ ALU_CLB   = 7'b0110101,
 
 // Sign-/zero-extensions
-parameter ALU_EXTS  = 7'b0111110;
-parameter ALU_EXT   = 7'b0111111;
+ ALU_EXTS  = 7'b0111110,
+ ALU_EXT   = 7'b0111111,
 
 // Comparisons
-parameter ALU_LTS   = 7'b0000000;
-parameter ALU_LTU   = 7'b0000001;
-parameter ALU_LES   = 7'b0000100;
-parameter ALU_LEU   = 7'b0000101;
-parameter ALU_GTS   = 7'b0001000;
-parameter ALU_GTU   = 7'b0001001;
-parameter ALU_GES   = 7'b0001010;
-parameter ALU_GEU   = 7'b0001011;
-parameter ALU_EQ    = 7'b0001100;
-parameter ALU_NE    = 7'b0001101;
+ ALU_LTS   = 7'b0000000,
+ ALU_LTU   = 7'b0000001,
+ ALU_LES   = 7'b0000100,
+ ALU_LEU   = 7'b0000101,
+ ALU_GTS   = 7'b0001000,
+ ALU_GTU   = 7'b0001001,
+ ALU_GES   = 7'b0001010,
+ ALU_GEU   = 7'b0001011,
+ ALU_EQ    = 7'b0001100,
+ ALU_NE    = 7'b0001101,
 
 // Set Lower Than operations
-parameter ALU_SLTS  = 7'b0000010;
-parameter ALU_SLTU  = 7'b0000011;
-parameter ALU_SLETS = 7'b0000110;
-parameter ALU_SLETU = 7'b0000111;
+ ALU_SLTS  = 7'b0000010,
+ ALU_SLTU  = 7'b0000011,
+ ALU_SLETS = 7'b0000110,
+ ALU_SLETU = 7'b0000111,
 
 // Absolute value
-parameter ALU_ABS   = 7'b0010100;
-parameter ALU_CLIP  = 7'b0010110;
-parameter ALU_CLIPU = 7'b0010111;
+ ALU_ABS   = 7'b0010100,
+ ALU_CLIP  = 7'b0010110,
+ ALU_CLIPU = 7'b0010111,
 
 // Insert/extract
-parameter ALU_INS   = 7'b0101101;
+ ALU_INS   = 7'b0101101,
 
 // min/max
-parameter ALU_MIN   = 7'b0010000;
-parameter ALU_MINU  = 7'b0010001;
-parameter ALU_MAX   = 7'b0010010;
-parameter ALU_MAXU  = 7'b0010011;
+ ALU_MIN   = 7'b0010000,
+ ALU_MINU  = 7'b0010001,
+ ALU_MAX   = 7'b0010010,
+ ALU_MAXU  = 7'b0010011,
 
 // div/rem
-parameter ALU_DIVU  = 7'b0110000; // bit 0 is used for signed mode, bit 1 is used for remdiv
-parameter ALU_DIV   = 7'b0110001; // bit 0 is used for signed mode, bit 1 is used for remdiv
-parameter ALU_REMU  = 7'b0110010; // bit 0 is used for signed mode, bit 1 is used for remdiv
-parameter ALU_REM   = 7'b0110011; // bit 0 is used for signed mode, bit 1 is used for remdiv
+ ALU_DIVU  = 7'b0110000, // bit 0 is used for signed mode, bit 1 is used for remdiv
+ ALU_DIV   = 7'b0110001, // bit 0 is used for signed mode, bit 1 is used for remdiv
+ ALU_REMU  = 7'b0110010, // bit 0 is used for signed mode, bit 1 is used for remdiv
+ ALU_REM   = 7'b0110011, // bit 0 is used for signed mode, bit 1 is used for remdiv
 
-parameter ALU_SHUF  = 7'b0111010;
-parameter ALU_SHUF2 = 7'b0111011;
-parameter ALU_PCKLO = 7'b0111000;
-parameter ALU_PCKHI = 7'b0111001;
+ ALU_SHUF  = 7'b0111010,
+ ALU_SHUF2 = 7'b0111011,
+ ALU_PCKLO = 7'b0111000,
+ ALU_PCKHI = 7'b0111001
+
+} alu_opcode_e;
 
 parameter MUL_MAC32 = 3'b000;
 parameter MUL_MSU32 = 3'b001;


### PR DESCRIPTION
Hi @Silabs-ArjanB , with this PR the ALU is now showing in the waveform the name of the operation rather than it's value. Making debug easier.

It should be LEC as it's just a style change. If you like it, I make it also for the multiplier and CSR operation