### PR TITLE
fix for DC Shell

### DIFF
--- a/rtl/cv32e40p_mult.sv
+++ b/rtl/cv32e40p_mult.sv
@@ -136,7 +136,7 @@ module cv32e40p_mult import cv32e40p_pkg::*;
     multicycle_o     = 1'b0;
 
     case (mulh_CS)
-      BEGIN: begin
+      IDLE_MULT: begin
         mulh_active = 1'b0;
         mulh_ready  = 1'b1;
         mulh_save   = 1'b0;
@@ -190,7 +190,7 @@ module cv32e40p_mult import cv32e40p_pkg::*;
         mulh_subword = 2'b11;
         mulh_ready   = 1'b1;
         if (ex_ready_i)
-          mulh_NS = BEGIN;
+          mulh_NS = IDLE_MULT;
       end
     endcase
   end
@@ -199,7 +199,7 @@ module cv32e40p_mult import cv32e40p_pkg::*;
   begin
     if (~rst_n)
     begin
-      mulh_CS      <= BEGIN;
+      mulh_CS      <= IDLE_MULT;
       mulh_carry_q <= 1'b0;
     end else begin
       mulh_CS      <= mulh_NS;

--- a/rtl/cv32e40p_mult.sv
+++ b/rtl/cv32e40p_mult.sv
@@ -58,8 +58,6 @@ module cv32e40p_mult import cv32e40p_pkg::*;
   input  logic        ex_ready_i
 );
 
-  import cv32e40p_pkg::*;
-
   ///////////////////////////////////////////////////////////////
   //  ___ _  _ _____ ___ ___ ___ ___   __  __ _   _ _  _____   //
   // |_ _| \| |_   _| __/ __| __| _ \ |  \/  | | | | ||_   _|  //
@@ -93,7 +91,7 @@ module cv32e40p_mult import cv32e40p_pkg::*;
   logic        mulh_clearcarry;
   logic        mulh_ready;
 
-  enum logic [2:0] {IDLE, STEP0, STEP1, STEP2, FINISH} mulh_CS, mulh_NS;
+  mult_state_e mulh_CS, mulh_NS;
 
   // prepare the rounding value
   assign short_round_tmp = (32'h00000001) << imm_i;
@@ -138,7 +136,7 @@ module cv32e40p_mult import cv32e40p_pkg::*;
     multicycle_o     = 1'b0;
 
     case (mulh_CS)
-      IDLE: begin
+      BEGIN: begin
         mulh_active = 1'b0;
         mulh_ready  = 1'b1;
         mulh_save   = 1'b0;
@@ -192,7 +190,7 @@ module cv32e40p_mult import cv32e40p_pkg::*;
         mulh_subword = 2'b11;
         mulh_ready   = 1'b1;
         if (ex_ready_i)
-          mulh_NS = IDLE;
+          mulh_NS = BEGIN;
       end
     endcase
   end
@@ -201,7 +199,7 @@ module cv32e40p_mult import cv32e40p_pkg::*;
   begin
     if (~rst_n)
     begin
-      mulh_CS      <= IDLE;
+      mulh_CS      <= BEGIN;
       mulh_carry_q <= 1'b0;
     end else begin
       mulh_CS      <= mulh_NS;

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -205,6 +205,8 @@ typedef enum logic [2:0] { HAVERESET = 3'b001, RUNNING = 3'b010, HALTED = 3'b100
 
 typedef enum logic {IDLE, BRANCH_WAIT} prefetch_state_e;
 
+typedef enum logic [2:0] {BEGIN, STEP0, STEP1, STEP2, FINISH} mult_state_e;
+
 /////////////////////////////////////////////////////////
 //    ____ ____    ____            _     _             //
 //   / ___/ ___|  |  _ \ ___  __ _(_)___| |_ ___ _ __  //

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -205,7 +205,7 @@ typedef enum logic [2:0] { HAVERESET = 3'b001, RUNNING = 3'b010, HALTED = 3'b100
 
 typedef enum logic {IDLE, BRANCH_WAIT} prefetch_state_e;
 
-typedef enum logic [2:0] {BEGIN, STEP0, STEP1, STEP2, FINISH} mult_state_e;
+typedef enum logic [2:0] {IDLE_MULT, STEP0, STEP1, STEP2, FINISH} mult_state_e;
 
 /////////////////////////////////////////////////////////
 //    ____ ____    ____            _     _             //


### PR DESCRIPTION
IDLE is defined both in the prefetcher FSM and the MULT FSM.

DC Shell does not like that as:

```
dc_shell> analyze -format sverilog  -work work ${DESIGN_RTL_DIR}/cv32e40p_mult.sv
Running PRESTO HDLC
Compiling source file ../../riscv/rtl//cv32e40p_mult.sv
Error:  ../../riscv/rtl//cv32e40p_mult.sv:96: redeclaration of symbol IDLE as constant. (VER-513)
Error:  ../../riscv/rtl//cv32e40p_mult.sv:96: symbol IDLE must be a constant or parameter. (VER-260)
* Presto compilation terminated with 2 errors. *
```

This PR solves it