### PR TITLE
Add missing license headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 language: cpp
 # run on new infrastructure
 dist: xenial

--- a/Bender.yml
+++ b/Bender.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package:
   name: riscv
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 node ('centos7' + ' && !vm1-centos7'){
     try {
 	stage('Preparation') {

--- a/ci/build-riscv-gcc.sh
+++ b/ci/build-riscv-gcc.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # call with first argument = 0 to checkout only
 set -o pipefail
 set -e

--- a/ci/download-pulp-gcc.sh
+++ b/ci/download-pulp-gcc.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
 set -o pipefail
 set -e
 

--- a/ci/get-openocd.sh
+++ b/ci/get-openocd.sh
@@ -1,4 +1,18 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 

--- a/ci/make-tmp.sh
+++ b/ci/make-tmp.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 [ -d tmp ] || rm -rf tmp

--- a/ci/openocd-to-junit.py
+++ b/ci/openocd-to-junit.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
 import sys, getopt
 from junit_xml import *
 

--- a/ci/run-openocd-compliance.sh
+++ b/ci/run-openocd-compliance.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
 set -e
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)

--- a/ci/rv32tests-to-junit.py
+++ b/ci/rv32tests-to-junit.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
 import sys, getopt
 from junit_xml import *
 

--- a/ci/veri-run-openocd-compliance.sh
+++ b/ci/veri-run-openocd-compliance.sh
@@ -1,4 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Robert Balas <balasr@iis.ee.ethz.ch>
 
 set -e
 

--- a/example_tb/core/amo_shim.sv
+++ b/example_tb/core/amo_shim.sv
@@ -1,3 +1,13 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
 /// Description: Governs atomic memory oeprations. This module needs to be instantiated
 /// in front of an SRAM. It needs to have exclusive access over it.
 

--- a/example_tb/core/custom/hello_world.c
+++ b/example_tb/core/custom/hello_world.c
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Robert Balas <balasr@iis.ee.ethz.ch>
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example_tb/core/custom_fp/main.c
+++ b/example_tb/core/custom_fp/main.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/example_tb/core/custom_fp/matmulNxN.c
+++ b/example_tb/core/custom_fp/matmulNxN.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 void matmulNxN(float* matA, float* matB , float* matC, int N)
 {
   float tot;

--- a/example_tb/core/firmware/stats.c
+++ b/example_tb/core/firmware/stats.c
@@ -1,9 +1,19 @@
-// This is free and unencumbered software released into the public domain.
-//
-// Anyone is free to copy, modify, publish, use, compile, sell, or
-// distribute this software, either in source code form or as a compiled
-// binary, for any purpose, commercial or non-commercial, and by any
-// means.
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 #include "firmware.h"
 

--- a/example_tb/core/hwlp_test/hwlp.h
+++ b/example_tb/core/hwlp_test/hwlp.h
@@ -1,4 +1,21 @@
 /*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
 
 HW-Loop realted macros for testing cv32e40p
 

--- a/example_tb/core/hwlp_test/hwlp_test.c
+++ b/example_tb/core/hwlp_test/hwlp_test.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "mem_stall.h"

--- a/example_tb/core/interrupt/interrupt.c
+++ b/example_tb/core/interrupt/interrupt.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/example_tb/core/interrupt/isr.h
+++ b/example_tb/core/interrupt/isr.h
@@ -1,9 +1,19 @@
-// This is free and unencumbered software released into the public domain.
-//
-// Anyone is free to copy, modify, publish, use, compile, sell, or
-// distribute this software, either in source code form or as a compiled
-// binary, for any purpose, commercial or non-commercial, and by any
-// means.
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 #ifndef FIRMWARE_H
 #define FIRMWARE_H

--- a/example_tb/core/interrupt/matrix.h
+++ b/example_tb/core/interrupt/matrix.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #define MAT_DIM    10
 
 uint32_t res[MAT_DIM][MAT_DIM];

--- a/example_tb/core/mem_stall/mem_stall.h
+++ b/example_tb/core/mem_stall/mem_stall.h
@@ -1,3 +1,19 @@
-// Header file for the memory stalls support
+/*
+ * Copyright 2020 ETH Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
+// Header file for the memory stalls support
 void activate_random_stall(void);

--- a/example_tb/core/software.tcl
+++ b/example_tb/core/software.tcl
@@ -1,3 +1,17 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # add fc execution trace
 set rvcores [find instances -recursive -bydu cv32e40p_core -nodu]
 set tracer [find instances -recursive -bydu cv32e40p_tracer -nodu]

--- a/example_tb/core/waves.tcl
+++ b/example_tb/core/waves.tcl
@@ -1,3 +1,21 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Author: Davide Schiavone <pschiavo@iis.ee.ethz.ch>
+#         Robert Balas <balasr@iis.ee.ethz.ch>
+
 # catch {
 #     if {$trdb_all ne ""} {
 #	foreach inst $trdb_all {

--- a/src_files.yml
+++ b/src_files.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cv32e40p_regfile_rtl:
   targets: [
     rtl,


### PR DESCRIPTION
Added license headers for files that are under ETH copyright. Technically already covered by the `LICENSE` file in the root folder, but this makes it more clear