### PR TITLE
Update src_files.yml

### DIFF
--- a/src_files.yml
+++ b/src_files.yml
@@ -35,6 +35,7 @@ cv32e40p:
   ]
   files: [
     ./rtl/include/cv32e40p_apu_core_pkg.sv,
+    ./rtl/include/cv32e40p_fpu_pkg.sv,
     ./rtl/include/cv32e40p_pkg.sv,
     ./bhv/include/cv32e40p_tracer_pkg.sv,
     ./rtl/cv32e40p_alu.sv,


### PR DESCRIPTION
Added cv32e40p_fpu_pkg.sv to src_files.yml because the package is used in cv32e40p_{decoder,id_stage}.sv and without this Vivado fails