### PR TITLE
remove PMP from src file

### DIFF
--- a/src_files.yml
+++ b/src_files.yml
@@ -22,13 +22,10 @@ cv32e40p_regfile_rtl:
     ./rtl/include,
   ]
   files: [
-    ./rtl/cv32e40p_register_file_latch.sv,
+    ./rtl/cv32e40p_register_file_ff.sv,
   ]
 
 cv32e40p:
-  vlog_opts: [
-    -L fpnew_lib,
-  ]
   incdirs: [
     ./rtl/include,
     ../../rtl/includes,
@@ -60,8 +57,7 @@ cv32e40p:
     ./rtl/cv32e40p_sleep_unit.sv,
     ./rtl/cv32e40p_core.sv,
     ./rtl/cv32e40p_apu_disp.sv,
-    ./rtl/cv32e40p_fifo.sv,
-    ./rtl/cv32e40p_pmp.sv,
+    ./rtl/cv32e40p_fifo.sv
   ]
 
 cv32e40p_vip_rtl:

--- a/src_files.yml
+++ b/src_files.yml
@@ -35,6 +35,7 @@ cv32e40p:
   ]
   files: [
     ./rtl/include/cv32e40p_apu_core_pkg.sv,
+    ./rtl/include/cv32e40p_fpu_pkg.sv,
     ./rtl/include/cv32e40p_pkg.sv,
     ./bhv/include/cv32e40p_tracer_pkg.sv,
     ./rtl/cv32e40p_alu.sv,


### PR DESCRIPTION
It removes the PMP for #609 and updates the src file to use the FF reg file.
It includes the PR to be accepted #604

This PR should be merged after #604 and after having a LEC CI in place