### PR TITLE
Remove cv32e40p pmp from synth

### DIFF
--- a/src_files.yml
+++ b/src_files.yml
@@ -35,6 +35,7 @@ cv32e40p:
   ]
   files: [
     ./rtl/include/cv32e40p_apu_core_pkg.sv,
+    ./rtl/include/cv32e40p_fpu_pkg.sv,
     ./rtl/include/cv32e40p_pkg.sv,
     ./bhv/include/cv32e40p_tracer_pkg.sv,
     ./rtl/cv32e40p_alu.sv,


### PR DESCRIPTION
This file causes Synopsys to fail (doesn't like redefinitiion of IDLE) and the documentation says that it is  not required for synthesis.