### PR TITLE
Make OBI specs easier to find

### DIFF
--- a/docs/source/apu.rst
+++ b/docs/source/apu.rst
@@ -52,9 +52,6 @@ Auxiliary Processing Unit Interface
 Protocol
 --------
 
-The apu bus interface is derived from to the OBI (Open Bus Interface) protocol.
-See https://github.com/openhwgroup/core-v-docs/blob/master/cores/obi/OBI-v1.2.pdf
-for details about the protocol.
 The CV32E40P apu interface uses the ``apu_operands_o``, ``apu_op_o``, and ``apu_flags_o`` as the address signal during the Address phase, indicating its validity with the ``apu_req_o`` signal. It uses the ``apu_result_i`` and ``apu_flags_i`` as the rdata of the response phase. It does not implement the OBI signals: we, be, wdata, auser, wuser, aid,
 rready, err, ruser, rid. These signals can be thought of as being tied off as
 specified in the OBI specification.

--- a/docs/source/instruction_fetch.rst
+++ b/docs/source/instruction_fetch.rst
@@ -69,9 +69,7 @@ The LSB of the instruction address is ignored internally.
 Protocol
 --------
 
-The instruction bus interface is compliant to the OBI (Open Bus Interface) protocol.
-See https://github.com/openhwgroup/core-v-docs/blob/master/cores/obi/OBI-v1.2.pdf
-for details about the protocol. The CV32E40P instruction fetch interface does not
+The CV32E40P instruction fetch interface does not
 implement the following optional OBI signals: we, be, wdata, auser, wuser, aid,
 rready, err, ruser, rid. These signals can be thought of as being tied off as
 specified in the OBI specification. The CV32E40P instruction fetch interface can

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -48,6 +48,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+Bus Interfaces
+--------------
+
+The Instruction Fetch and Load/Store data bus interfaces are compliant to the **OBI** (Open Bus Interface) protocol.
+See https://github.com/openhwgroup/core-v-docs/blob/master/cores/obi/OBI-v1.2.pdf for details about the protocol.
+Additional information can be found in the :ref:`instruction-fetch` and :ref:`load-store-unit` chapters of this document.
+
+The Auxiliary Processing Unit bus interface is derived from to the OBI (Open Bus Interface) protocol, see the :ref:`apu` chapter of this document.
+
 Standards Compliance
 --------------------
 

--- a/docs/source/load_store_unit.rst
+++ b/docs/source/load_store_unit.rst
@@ -66,9 +66,7 @@ In both cases the transfer corresponding to the lowest address is performed firs
 Protocol
 --------
 
-The data bus interface is compliant to the OBI (Open Bus Interface) protocol.
-See https://github.com/openhwgroup/core-v-docs/blob/master/cores/obi/OBI-v1.2.pdf
-for details about the protocol. The CV32E40P data interface does not implement
+The CV32E40P data interface does not implement
 the following optional OBI signals: auser, wuser, aid, rready, err, ruser, rid.
 These signals can be thought of as being tied off as specified in the OBI
 specification. The CV32E40P data interface can cause up to two outstanding


### PR DESCRIPTION
I keep getting two questions about the CV32E40P:
1, What are the memory bus interfaces?
2. Where is the location of the OBI spec.?

Both are clearly answered in the User Manual, but it seems the information is not as easy to find as it might be. This PR puts the OBI reference in the Introduction section, which _should_ make it easy to find.  In keeping with the "do not repeat yourself" principle of documentation, the links to the spec from the other chapters that reference it have been removed.

By definition this PR will pass an RTL LE check. :wink:

Signed-off-by: Mike Thompson <mike@openhwgroup.org>