### PR TITLE
Fix tracer for FPU

### DIFF
--- a/bhv/cv32e40p_instr_trace.svh
+++ b/bhv/cv32e40p_instr_trace.svh
@@ -61,7 +61,7 @@ class instr_trace_t;
   reg_t        regs_read[$];
   reg_t        regs_write[$];
   mem_acc_t    mem_access[$];
-  logic        retired;
+  logic        is_apu;
 
   function new();
     str        = "";

--- a/bhv/cv32e40p_instr_trace.svh
+++ b/bhv/cv32e40p_instr_trace.svh
@@ -389,9 +389,14 @@ class instr_trace_t;
       regs_read.push_back('{rs2, rs2_value, 0});
       regs_read.push_back('{rs4, rs3_value, 0});
       regs_write.push_back('{rd, 'x, 0});
-      str = $sformatf(
-          "%-16s f%0d, f%0d, f%0d, f%0d", mnemonic, rd - 32, rs1 - 32, rs2 - 32, rs4 - 32
-      );
+      if (PULP_ZFINX)
+        str = $sformatf(
+            "%-16s x%0d, x%0d, x%0d, x%0d", mnemonic, rd, rs1, rs2, rs4
+        );
+      else
+        str = $sformatf(
+            "%-16s f%0d, f%0d, f%0d, f%0d", mnemonic, rd - 32, rs1 - 32, rs2 - 32, rs4 - 32
+        );
     end
   endfunction  // printF3Instr
 
@@ -400,7 +405,10 @@ class instr_trace_t;
       regs_read.push_back('{rs1, rs1_value, 0});
       regs_read.push_back('{rs2, rs2_value, 0});
       regs_write.push_back('{rd, 'x, 0});
-      str = $sformatf("%-16s f%0d, f%0d, f%0d", mnemonic, rd - 32, rs1 - 32, rs2 - 32);
+      if (PULP_ZFINX)
+        str = $sformatf("%-16s x%0d, x%0d, x%0d", mnemonic, rd, rs1, rs2);
+      else
+        str = $sformatf("%-16s f%0d, f%0d, f%0d", mnemonic, rd - 32, rs1 - 32, rs2 - 32);
     end
   endfunction  // printF2Instr
 
@@ -409,7 +417,10 @@ class instr_trace_t;
       regs_read.push_back('{rs1, rs1_value, 0});
       regs_read.push_back('{rs2, rs2_value, 0});
       regs_write.push_back('{rd, 'x, 0});
-      str = $sformatf("%-16s x%0d, f%0d, f%0d", mnemonic, rd, rs1 - 32, rs2 - 32);
+      if (PULP_ZFINX)
+        str = $sformatf("%-16s x%0d, x%0d, x%0d", mnemonic, rd, rs1, rs2);
+      else
+        str = $sformatf("%-16s x%0d, f%0d, f%0d", mnemonic, rd, rs1 - 32, rs2 - 32);
     end
   endfunction  // printF2IInstr
 
@@ -417,7 +428,10 @@ class instr_trace_t;
     begin
       regs_read.push_back('{rs1, rs1_value, 0});
       regs_write.push_back('{rd, 'x, 0});
-      str = $sformatf("%-16s f%0d, f%0d", mnemonic, rd - 32, rs1 - 32);
+      if (PULP_ZFINX)
+        str = $sformatf("%-16s x%0d, x%0d", mnemonic, rd, rs1);
+      else
+        str = $sformatf("%-16s f%0d, f%0d", mnemonic, rd - 32, rs1 - 32);
     end
   endfunction  // printFInstr
 
@@ -425,7 +439,10 @@ class instr_trace_t;
     begin
       regs_read.push_back('{rs1, rs1_value, 0});
       regs_write.push_back('{rd, 'x, 0});
-      str = $sformatf("%-16s x%0d, f%0d", mnemonic, rd, rs1 - 32);
+      if (PULP_ZFINX)
+        str = $sformatf("%-16s x%0d, x%0d", mnemonic, rd, rs1);
+      else
+        str = $sformatf("%-16s x%0d, f%0d", mnemonic, rd, rs1 - 32);
     end
   endfunction  // printFIInstr
 
@@ -434,7 +451,10 @@ class instr_trace_t;
       mnemonic = {compressed ? "c." : "", mnemonic};
       regs_read.push_back('{rs1, rs1_value, 0});
       regs_write.push_back('{rd, 'x, 0});
-      str = $sformatf("%-16s f%0d, x%0d", mnemonic, rd - 32, rs1);
+      if (PULP_ZFINX)
+        str = $sformatf("%-16s x%0d, x%0d", mnemonic, rd, rs1);
+      else
+        str = $sformatf("%-16s f%0d, x%0d", mnemonic, rd - 32, rs1);
     end
   endfunction  // printIFInstr
 

--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -28,8 +28,9 @@
 
 module cv32e40p_tracer
   import cv32e40p_pkg::*;
-  import uvm_pkg::*;
-(
+  import uvm_pkg::*; #(
+    parameter PULP_ZFINX = 0
+)(
   // Clock and Reset
   input  logic        clk_i,
   input  logic        rst_n,
@@ -185,11 +186,11 @@ module cv32e40p_tracer
 
   always @(trace_wb) trace_wb_is_delay_instr = (trace_wb != null && is_wb_delay_instr(trace_wb)) ? 1 : 0;
 
-  assign rd  = {rd_is_fp,  instr[11:07]};
-  assign rs1 = {rs1_is_fp, instr[19:15]};
-  assign rs2 = {rs2_is_fp, instr[24:20]};
-  assign rs3 = {rs3_is_fp, instr[29:25]};
-  assign rs4 = {rs3_is_fp, instr[31:27]};
+  assign rd  = {PULP_ZFINX ? 0 : rd_is_fp,  instr[11:07]};
+  assign rs1 = {PULP_ZFINX ? 0 : rs1_is_fp, instr[19:15]};
+  assign rs2 = {PULP_ZFINX ? 0 : rs2_is_fp, instr[24:20]};
+  assign rs3 = {PULP_ZFINX ? 0 : rs3_is_fp, instr[29:25]};
+  assign rs4 = {PULP_ZFINX ? 0 : rs3_is_fp, instr[31:27]};
 
   function void apply_reg_write(instr_trace_t trace, int unsigned reg_addr, int unsigned wdata);
     foreach (trace.regs_write[i])

--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -94,7 +94,11 @@ module cv32e40p_tracer
   input  logic [31:0] imm_vs_type,
   input  logic [31:0] imm_vu_type,
   input  logic [31:0] imm_shuffle_type,
-  input  logic [ 4:0] imm_clip_type
+  input  logic [ 4:0] imm_clip_type,
+
+  input logic         apu_en_i,
+  input logic         apu_rvalid_i
+
 );
 
   import cv32e40p_tracer_pkg::*;
@@ -111,8 +115,9 @@ module cv32e40p_tracer
   integer      cycles;
   logic [ 5:0] rd, rs1, rs2, rs3, rs4;
 
-  logic [31:0] pc_ex_stage;  
-  logic [31:0] pc_wb_stage;  
+  logic [31:0] pc_ex_stage;
+  logic [31:0] pc_ex_delay_stage;
+  logic [31:0] pc_wb_stage;
   logic [31:0] pc_wb_delay_stage;
   logic [31:0] pc_retire_head_q;
 
@@ -125,12 +130,16 @@ module cv32e40p_tracer
   instr_trace_t trace_ex;  
   instr_trace_t trace_wb;
   instr_trace_t trace_wb_delay;
-  
-  bit clear_trace_ex;  
+  instr_trace_t trace_ex_delay;
+
+  bit clear_trace_ex;
   bit move_trace_ex_to_trace_wb;
   bit clear_trace_wb;
   bit move_trace_wb_to_trace_wb_delay;
   bit clear_trace_wb_delay;
+  bit move_trace_ex_to_trace_ex_delay;
+  bit clear_trace_ex_delay;
+  bit move_trace_ex_delay_to_trace_wb;
 
   bit trace_new;
   bit trace_new_ebreak;
@@ -142,8 +151,11 @@ module cv32e40p_tracer
 
   bit trace_wb_delay_is_null;
   bit trace_wb_is_null;
-  bit trace_ex_is_null;
   bit trace_wb_is_delay_instr;
+
+  bit trace_ex_delay_is_null;
+  bit trace_ex_is_null;
+  bit trace_ex_is_delay_instr;
 
   string       insn_disas;
   logic        insn_compressed;
@@ -177,8 +189,9 @@ module cv32e40p_tracer
       use_iss = 1;
   end
 
-  always @(trace_ex or trace_wb or trace_wb_delay or trace_retire) begin
+  always @(trace_ex or trace_ex_delay or trace_wb or trace_wb_delay or trace_retire) begin
     pc_ex_stage = (trace_ex != null) ? trace_ex.pc : 'x;
+    pc_ex_delay_stage = (trace_ex_delay != null) ? trace_ex_delay.pc : 'x;
     pc_wb_stage = (trace_wb != null) ? trace_wb.pc : 'x;
     pc_wb_delay_stage = (trace_wb_delay != null) ? trace_wb_delay.pc : 'x;  
     pc_retire_head_q = (trace_retire != null) ? trace_retire.pc : 'x;  
@@ -296,6 +309,24 @@ module cv32e40p_tracer
     end
   end
 
+  // EX delay stage
+  always @(negedge clk_i_d or negedge rst_n )begin
+    if (!rst_n) begin
+      trace_ex_delay <= null;
+      trace_ex_delay_is_null <= 1;
+    end
+    else begin
+      if (move_trace_ex_to_trace_ex_delay) begin
+        trace_ex_delay <= trace_ex;
+        trace_ex_delay_is_null <= (trace_ex == null) ? 1 : 0;
+      end
+      else if (clear_trace_ex_delay) begin
+        trace_ex_delay <= null;
+        trace_ex_delay_is_null <= 1;
+      end
+    end
+  end
+
   // WB stage
   always @(negedge clk_i_d or negedge rst_n )begin
     if (rst_n) begin
@@ -319,9 +350,11 @@ module cv32e40p_tracer
       if (move_trace_ex_to_trace_wb) begin
         trace_wb <= trace_ex;
         trace_wb_is_null <= (trace_ex == null) ? 1 :  0;
-      end
-      else if (clear_trace_wb) begin
-        trace_wb <= null;      
+      end else if (move_trace_ex_delay_to_trace_wb) begin
+        trace_wb <= trace_ex_delay;
+        trace_wb_is_null <= (trace_ex_delay == null) ? 1 :  0;
+      end else if (clear_trace_wb) begin
+        trace_wb <= null;
         trace_wb_is_null <= 1;
       end
     end
@@ -372,6 +405,11 @@ module cv32e40p_tracer
     move_trace_wb_to_trace_wb_delay = 0;
     clear_trace_wb_delay = 0;
 
+    move_trace_ex_to_trace_ex_delay = 0;
+    move_trace_ex_delay_to_trace_wb = 0;
+    clear_trace_ex_delay = 0;
+
+
     // ----------------------------------------------
     // WB Delay logic
     // ----------------------------------------------
@@ -396,7 +434,19 @@ module cv32e40p_tracer
         end
       end
     end
-    
+
+    // ----------------------------------------------
+    // EX Delay logic
+    // ----------------------------------------------
+    // apu_rvalid_i for variable latency apu offloading
+    // non apu instructions will always go to wb as fast as possible (i.e. next cycle)
+    if (trace_ex_delay != null) begin
+      if (apu_rvalid_i || !trace_ex_delay.is_apu) begin
+        move_trace_ex_delay_to_trace_wb = 1;
+        clear_trace_ex_delay            = 1;
+      end
+    end
+
     // ----------------------------------------------
     // EX logic
     // ----------------------------------------------
@@ -417,13 +467,30 @@ module cv32e40p_tracer
       trace_ex_wb_bypass = 1;
       
       clear_trace_ex = 1;
-    end
+    // Some instructons get an extra cycle to retire
+    // offload to (potentially) multicycle APU/FPU
+    end else if (!trace_ex_is_null && apu_en_i && !apu_rvalid_i) begin
+      move_trace_ex_to_trace_ex_delay = 1;
+      clear_trace_ex                  = 1;
+      trace_ex.is_apu                 = 1;
+
     // Instruction leaves EX
-    else if (!trace_ex_is_null && ex_valid && !data_misaligned) begin      
+    end else if (!trace_ex_is_null && ex_valid && !data_misaligned) begin
+      // if ex delay is already writing to wb then we also delay this one
+      if (move_trace_ex_delay_to_trace_wb) begin
+        move_trace_ex_to_trace_ex_delay = 1;
+        clear_trace_ex              = 1;
+        trace_ex.is_apu             = 0;
+      end else begin
       move_trace_ex_to_trace_wb = 1;
       clear_trace_ex = 1;
     end
   end
+
+    if (move_trace_ex_to_trace_wb && move_trace_ex_delay_to_trace_wb)
+      $error("ex delay stage and ex stage collide");
+  end
+
 
   // Monitors for memory access and register writeback
   always @(negedge clk_i or negedge rst_n) begin
@@ -443,7 +510,9 @@ module cv32e40p_tracer
       // Register updates in WB
       if (wb_reg_we) begin
         `uvm_info(info_tag, $sformatf("WB: Reg WR %02d = 0x%08x", wb_reg_addr, wb_reg_wdata), UVM_DEBUG);
-        if (trace_wb != null)
+        if (trace_ex_delay != null)
+          apply_reg_write(trace_ex_delay, wb_reg_addr, wb_reg_wdata);
+        else if (trace_wb != null)
           apply_reg_write(trace_wb, wb_reg_addr, wb_reg_wdata);
         else if (trace_ex != null && trace_ex.misaligned)
           apply_reg_write(trace_ex, wb_reg_addr, wb_reg_wdata);

--- a/bhv/cv32e40p_wrapper.sv
+++ b/bhv/cv32e40p_wrapper.sv
@@ -196,7 +196,9 @@ module cv32e40p_wrapper
       .imm_vs_type     (core_i.id_stage_i.imm_vs_type),
       .imm_vu_type     (core_i.id_stage_i.imm_vu_type),
       .imm_shuffle_type(core_i.id_stage_i.imm_shuffle_type),
-      .imm_clip_type   (core_i.id_stage_i.instr[11:7])
+      .imm_clip_type   (core_i.id_stage_i.instr[11:7]),
+      .apu_en_i        (core_i.ex_stage_i.apu_en_i),
+      .apu_rvalid_i    (core_i.ex_stage_i.apu_rvalid_i)
   );
 `endif
 

--- a/bhv/cv32e40p_wrapper.sv
+++ b/bhv/cv32e40p_wrapper.sv
@@ -135,7 +135,9 @@ module cv32e40p_wrapper
 `endif
 
 `ifdef CV32E40P_TRACE_EXECUTION
-  cv32e40p_tracer tracer_i (
+    cv32e40p_tracer #(
+      .PULP_ZFINX(PULP_ZFINX)
+    ) tracer_i (
       .clk_i(core_i.clk_i),  // always-running clock for tracing
       .rst_n(core_i.rst_ni),
 

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -917,7 +917,7 @@ module cv32e40p_core
   );
 
   // Tracer signal
-  assign wb_valid = lsu_ready_wb & apu_ready_wb;
+  assign wb_valid = lsu_ready_wb;
 
 
   //////////////////////////////////////


### PR DESCRIPTION
This PR addresses two issues:
Firstly,
when the FPU latency in `cv32e40p_pkg.sv` is changed to e.g.
```diff
-  parameter int unsigned C_LAT_FP32 = 'd0;
+  parameter int unsigned C_LAT_FP32 = 'd1;
```
then tracer will hang or write x's to the trace log. This is due to the tracer not correctly waiting for the APU handshaking to start and conclude in the execution stage. We fix this by introducing an execution delay stage to model these multi-cycle APU instructions.

and secondly when ZFINX is enabled, it still looks like as if the fpu instructions are referring to non-existing floating point registers. This is just a cosmetic issue.
