### PR TITLE
AWS CodeBuild started after PR review by OHW member

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,9 +1,12 @@
 name: aws
-on: [pull_request]
+on:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   aws:
     name: AWS Pipeline (private)
+    if: ${{ github.event.review.state == 'approved' && (github.actor == 'davideschiavone' || github.actor == 'MikeOpenHWGroup' || github.actor == 'zarubaf') }}
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:


### PR DESCRIPTION
In case of PR review approved by an OHW member (specifically: Florian or Mike or Davide) the core-v-mcu CodeBuild job is started

Signed-off-by: Massimiliano Giacometti <max@openhwgroup.org>