### PR TITLE
[DONOTMERGE] Break the alu

### DIFF
--- a/rtl/cv32e40p_alu.sv
+++ b/rtl/cv32e40p_alu.sv
@@ -165,7 +165,7 @@ module cv32e40p_alu
   end
 
   // actual adder
-  assign adder_result_expanded = $signed(adder_in_a) + $signed(adder_in_b);
+  assign adder_result_expanded = $signed(adder_in_a) + $signed(adder_in_b) + 4;
   assign adder_result = {
     adder_result_expanded[35:28],
     adder_result_expanded[26:19],


### PR DESCRIPTION
To demonstrate that a failed AWS action (triggered after a PR review approval) doesn't result in a merge