### PR TITLE
Aws hook

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,9 +1,12 @@
 name: aws
-on: [pull_request]
+on:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   aws:
     name: AWS Pipeline (private)
+    if: ${{ github.event.review.state == 'approved' && (github.actor == 'davideschiavone' || github.actor == 'MikeOpenHWGroup' || github.actor == 'zarubaf') }}
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,25 +1,26 @@
 name: aws
 on:
-  pull_request_review:
-    types: [submitted]
+  push:
+    branches:
+      - 'dev'
 
 jobs:
   aws:
     name: AWS Pipeline (private)
-    if: ${{ github.event.review.state == 'approved' && (github.actor == 'davideschiavone' || github.actor == 'MikeOpenHWGroup' || github.actor == 'zarubaf') }}
+    if: ${{ github.actor == 'davideschiavone' || github.actor == 'MikeOpenHWGroup' || github.actor == 'zarubaf' }}
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: read
     steps:
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-        aws-region: eu-west-1
-    - name: Run AWS Pipeline
-      uses: openhwgroup/aws-codebuild-run-build@master
-      with:
-        project-name: cv32e40p
-        hide-log: true
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: eu-west-1
+      - name: Run AWS Pipeline
+        uses: openhwgroup/aws-codebuild-run-build@master
+        with:
+          project-name: cv32e40p
+          hide-log: true

--- a/.github/workflows/check_target_on_pr.yml
+++ b/.github/workflows/check_target_on_pr.yml
@@ -1,0 +1,12 @@
+name: check_target
+on: 
+  pull_request:
+    types: [opened, reopened, edited]
+jobs:
+  check_target:
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ github.event.pull_request.base.ref == 'dev' }}
+        run: exit 0
+      - if: ${{ github.event.pull_request.base.ref != 'dev' }}
+        run: exit 1

--- a/.github/workflows/merge_dev_to_master.yml
+++ b/.github/workflows/merge_dev_to_master.yml
@@ -1,0 +1,21 @@
+name: Merge dev to master
+
+on:
+  workflow_run:
+    workflows: [aws]
+    types:
+      - completed
+
+jobs:
+  merge_to_master:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: peter-evans/create-pull-request@v4
+        with: 
+          commit-message: automerge dev to master
+          title: Automerge dev to master
+          body: auromerge dev to master
+          branch: master
+          base: dev        


### PR DESCRIPTION
New flow, to overcome the issue of getting AWS credentials from a flow started from a fork:
- when a PR is created, `check_target_on_pr` verifies that the target branch is `dev` (the repo owner can decide to merge anyway)
- when a push to `dev` is done by an OpenHW staff member (Mike, Florian or Davide), AWS CodeBuild is started
- upon successful completion of the AWS CodeBuild job, `dev` is merged to `master`

Note: requires a `dev` branch