### PR TITLE
update wrapper for synthesis

### DIFF
--- a/bhv/cv32e40p_wrapper.sv
+++ b/bhv/cv32e40p_wrapper.sv
@@ -109,6 +109,7 @@ module cv32e40p_wrapper
 
 `endif  // CV32E40P_ASSERT_ON
 
+`ifndef SYNTHESIS
   cv32e40p_core_log #(
       .PULP_XPULP      (PULP_XPULP),
       .PULP_CLUSTER    (PULP_CLUSTER),
@@ -122,6 +123,7 @@ module cv32e40p_wrapper
       .hart_id_i         (core_i.hart_id_i),
       .pc_id_i           (core_i.pc_id)
   );
+`endif  // SYNTHESIS
 
 `ifdef CV32E40P_APU_TRACE
   cv32e40p_apu_tracer apu_tracer_i (


### PR DESCRIPTION
when an MCU uses the wrapper as top module (to include log files for example, or the tracer) we need to exclude the core log from being synthesized