### PR TITLE
Fix rvfi for lec

### DIFF
--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -25,6 +25,11 @@
 `include "cv32e40p_tracer.sv"
 `endif
 
+`ifdef CV32E40P_RVFI
+`include "cv32e40p_rvfi.sv"
+`include "cv32e40p_rvfi_trace.sv"
+`endif
+
 module cv32e40p_tb_wrapper
   import cv32e40p_pkg::*;
 #(

--- a/cv32e40p_manifest.flist
+++ b/cv32e40p_manifest.flist
@@ -61,6 +61,3 @@ ${DESIGN_RTL_DIR}/cv32e40p_wrapper.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40p_sim_clock_gate.sv
 ${DESIGN_RTL_DIR}/../bhv/include/cv32e40p_tracer_pkg.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40p_tb_wrapper.sv
-${DESIGN_RTL_DIR}/../bhv/include/cv32e40p_rvfi_pkg.sv
-${DESIGN_RTL_DIR}/../bhv/cv32e40p_rvfi.sv
-${DESIGN_RTL_DIR}/../bhv/cv32e40p_rvfi_trace.sv


### PR DESCRIPTION
Removed rfvi files from manifest and added them to tb_wrapper embraced by ifdefs

Signed-off-by: Pascal Gouedo <pascal.gouedo@dolphin.fr>