### PR TITLE
Correcting RFVI trace

### DIFF
--- a/bhv/cv32e40p_rvfi_trace.sv
+++ b/bhv/cv32e40p_rvfi_trace.sv
@@ -27,9 +27,12 @@ module cv32e40p_rvfi_trace
   assign rst_n = rst_ni;
 
   integer f;  //file pointer
-  string  fn;
+  string fn;
   integer cycles;
-  string  info_tag;
+  string info_tag;
+
+  logic is_compressed;
+  logic [31:0] decomp_insn;
 
   logic [5:0] rd, rs1, rs2, rs3, rs4;
   //TODO get from rvfi
@@ -62,18 +65,32 @@ module cv32e40p_rvfi_trace
   assign rs2_value = rvfi_rs2_rdata;
   assign rs3_value = rvfi_rd_wdata;
 
-  assign imm_u_typ = '0;
-  assign imm_uj_typ = '0;
-  assign imm_i_typ = '0;
-  assign imm_iz_typ = '0;
-  assign imm_z_typ = '0;
-  assign imm_s_typ = '0;
-  assign imm_sb_typ = '0;
-  assign imm_s2_typ = '0;
-  assign imm_vs_typ = '0;
-  assign imm_vu_typ = '0;
-  assign imm_shuffle_typ = '0;
-  assign imm_clip_typ = '0;
+  assign imm_i_type = {{20{rvfi_insn[31]}}, rvfi_insn[31:20]};
+  assign imm_iz_type = {20'b0, rvfi_insn[31:20]};
+  assign imm_s_type = {{20{rvfi_insn[31]}}, rvfi_insn[31:25], rvfi_insn[11:7]};
+  assign imm_sb_type = {
+    {19{rvfi_insn[31]}}, rvfi_insn[31], rvfi_insn[7], rvfi_insn[30:25], rvfi_insn[11:8], 1'b0
+  };
+  assign imm_u_type = {rvfi_insn[31:12], 12'b0};
+  assign imm_uj_type = {
+    {12{rvfi_insn[31]}}, rvfi_insn[19:12], rvfi_insn[20], rvfi_insn[30:21], 1'b0
+  };
+
+  assign imm_z_type = '0;  //{27'b0, rvfi_insn[REG_S1_MSB:REG_S1_LSB]};
+
+  assign imm_s2_type = {27'b0, rvfi_insn[24:20]};
+  assign imm_vs_type = '0;
+  assign imm_vu_type = '0;
+  assign imm_shuffle_type = '0;
+  assign imm_clip_type = '0;
+
+  cv32e40p_compressed_decoder #(
+      .FPU(1)
+  ) rvfi_trace_decompress_i (
+      .instr_i(rvfi_insn),
+      .instr_o(decomp_insn),
+      .is_compressed_o(is_compressed)
+  );
 
   localparam FPU = 0;
   localparam PULP_ZFINX = 0;
@@ -82,11 +99,18 @@ instr_trace_t trace_retire;
 
   function instr_trace_t trace_new_instr();
     instr_trace_t trace;
-
     trace = new();
-    trace.init(.cycles(cycles), .pc(rvfi_pc_rdata), .compressed(0), .instr(rvfi_insn));
+    trace.init(.cycles(cycles), .pc(rvfi_pc_rdata), .compressed(is_compressed),
+               .instr(decomp_insn));
     return trace;
   endfunction : trace_new_instr
+
+  function void apply_reg_write();
+    foreach (trace_retire.regs_write[i])
+      if (trace_retire.regs_write[i].addr == rvfi_rd_addr) begin
+        trace_retire.regs_write[i].value = rvfi_rd_wdata;
+      end
+  endfunction : apply_reg_write
 
   // cycle counter
   always_ff @(posedge clk_i, negedge rst_ni) begin
@@ -97,7 +121,7 @@ instr_trace_t trace_retire;
   always @(posedge clk_i) begin
     if (rvfi_valid) begin
       trace_retire = trace_new_instr();
-
+      apply_reg_write();
       trace_retire.printInstrTrace();
     end
   end


### PR DESCRIPTION
The trace log file created from the RVFI was flawed. This PR fix this issue. The log file created from RVFI is now consistent with the previous tracer.
This PR is meant to replace the previous one with a properly signed commit