### PR TITLE
Fix _sbrk() allocation size wrongly doubled

### DIFF
--- a/example_tb/core/custom/syscalls.c
+++ b/example_tb/core/custom/syscalls.c
@@ -261,7 +261,7 @@ void *_sbrk(ptrdiff_t incr)
         return NULL;
     }
 
-    if ((brk += incr) < __heap_end) {
+    if ((brk + incr) < __heap_end) {
         brk += incr;
     } else {
         brk = __heap_end;


### PR DESCRIPTION
Looks like a typo.
I found the linker script, makefile and sys-calls implementation especially super useful, thanks!