### PR TITLE
mstatus fs addition & bug corrections

### DIFF
--- a/bhv/cv32e40p_core_log.sv
+++ b/bhv/cv32e40p_core_log.sv
@@ -37,8 +37,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_core_log #(
-    parameter PULP_XPULP          =  1,                   // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. p.elw) !!! HARDWARE LOOP IS NOT OPERATIONAL YET !!!
-    parameter PULP_CLUSTER = 0,  // PULP Cluster interface (incl. p.elw)
+    parameter COREV_PULP =  1,  // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. cv.elw)
+    parameter COREV_CLUSTER = 0,  // PULP Cluster interface (incl. cv.elw)
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
     parameter ZFINX = 0,  // Float-in-General Purpose registers
     parameter NUM_MHPMCOUNTERS = 1
@@ -53,8 +53,8 @@ module cv32e40p_core_log #(
   // Log top level parameter values
   initial begin
     $display(
-        "[cv32e40p_core]: PULP_XPULP = %d, PULP_CLUSTER = %d, FPU %d, ZFINX %d, NUM_MHPMCOUNTERS %d",
-        PULP_XPULP, PULP_CLUSTER, FPU, ZFINX, NUM_MHPMCOUNTERS);
+        "[cv32e40p_core]: COREV_PULP = %d, COREV_CLUSTER = %d, FPU %d, ZFINX %d, NUM_MHPMCOUNTERS %d",
+        COREV_PULP, COREV_CLUSTER, FPU, ZFINX, NUM_MHPMCOUNTERS);
   end
 
   // Log illegal instructions

--- a/bhv/cv32e40p_core_log.sv
+++ b/bhv/cv32e40p_core_log.sv
@@ -40,7 +40,7 @@ module cv32e40p_core_log #(
     parameter PULP_XPULP          =  1,                   // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. p.elw) !!! HARDWARE LOOP IS NOT OPERATIONAL YET !!!
     parameter PULP_CLUSTER = 0,  // PULP Cluster interface (incl. p.elw)
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
-    parameter PULP_ZFINX = 0,  // Float-in-General Purpose registers
+    parameter ZFINX = 0,  // Float-in-General Purpose registers
     parameter NUM_MHPMCOUNTERS = 1
 ) (
     input logic        clk_i,
@@ -53,8 +53,8 @@ module cv32e40p_core_log #(
   // Log top level parameter values
   initial begin
     $display(
-        "[cv32e40p_core]: PULP_XPULP = %d, PULP_CLUSTER = %d, FPU %d, PULP_ZFINX %d, NUM_MHPMCOUNTERS %d",
-        PULP_XPULP, PULP_CLUSTER, FPU, PULP_ZFINX, NUM_MHPMCOUNTERS);
+        "[cv32e40p_core]: PULP_XPULP = %d, PULP_CLUSTER = %d, FPU %d, ZFINX %d, NUM_MHPMCOUNTERS %d",
+        PULP_XPULP, PULP_CLUSTER, FPU, ZFINX, NUM_MHPMCOUNTERS);
   end
 
   // Log illegal instructions

--- a/bhv/cv32e40p_instr_trace.svh
+++ b/bhv/cv32e40p_instr_trace.svh
@@ -274,7 +274,7 @@ class instr_trace_t;
 
   function string regAddrToStr(input logic [5:0] addr);
     begin
-      if (SymbolicRegs==1 && (FPU==0 || PULP_ZFINX==0)) begin // format according to RISC-V ABI
+      if (SymbolicRegs==1 && (FPU==0 || ZFINX==0)) begin // format according to RISC-V ABI
         if (addr == 0) return $sformatf("zero");
         else if (addr ==       1) return $sformatf("  ra");
         else if (addr ==       2) return $sformatf("  sp");
@@ -568,7 +568,7 @@ class instr_trace_t;
           return;
         end
       endcase
-      if (FPU==1 && PULP_ZFINX==0) begin
+      if (FPU==1 && ZFINX==0) begin
         mnemonic = {fp, mnemonic};
       end
       mnemonic = {compressed ? "c." : "", mnemonic};
@@ -622,7 +622,7 @@ class instr_trace_t;
           return;
         end
       endcase
-      if (FPU==1 && PULP_ZFINX==0) begin
+      if (FPU==1 && ZFINX==0) begin
         mnemonic = {fp, mnemonic};
       end
       mnemonic = {compressed ? "c." : "", mnemonic};

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -189,6 +189,8 @@ module cv32e40p_rvfi
     input logic    csr_jvt_we_i,
     input Status_t csr_mstatus_n_i,
     input Status_t csr_mstatus_q_i,
+    input FS_t     csr_mstatus_fs_n_i,
+    input FS_t     csr_mstatus_fs_q_i,
 
     input logic        csr_mstatush_we_i,
     input logic [31:0] csr_misa_n_i,

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -26,8 +26,8 @@ module cv32e40p_rvfi
   import cv32e40p_pkg::*;
   import cv32e40p_rvfi_pkg::*;
 #(
-    parameter FPU        = 0,
-    parameter PULP_ZFINX = 0
+    parameter FPU   = 0,
+    parameter ZFINX = 0
 ) (
     input logic clk_i,
     input logic rst_ni,

--- a/bhv/cv32e40p_rvfi_trace.sv
+++ b/bhv/cv32e40p_rvfi_trace.sv
@@ -22,8 +22,8 @@
 module cv32e40p_rvfi_trace
   import cv32e40p_pkg::*;
 #(
-    parameter FPU        = 0,
-    parameter PULP_ZFINX = 0
+    parameter FPU   = 0,
+    parameter ZFINX = 0
 ) (
     input logic clk_i,
     input logic rst_ni,

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -48,7 +48,7 @@ module cv32e40p_tb_wrapper
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication computing lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion computing lanes pipeline registers number
-    parameter PULP_ZFINX = 0,  // Float-in-General Purpose registers
+    parameter ZFINX = 0,  // Float-in-General Purpose registers
     parameter NUM_MHPMCOUNTERS = 1
 ) (
     // Clock and Reset
@@ -118,7 +118,7 @@ module cv32e40p_tb_wrapper
       .PULP_XPULP      (PULP_XPULP),
       .PULP_CLUSTER    (PULP_CLUSTER),
       .FPU             (FPU),
-      .PULP_ZFINX      (PULP_ZFINX),
+      .ZFINX           (ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
   ) core_log_i (
       .clk_i             (cv32e40p_wrapper_i.core_i.id_stage_i.clk),
@@ -142,8 +142,8 @@ module cv32e40p_tb_wrapper
 
 `ifdef CV32E40P_TRACE_EXECUTION
   cv32e40p_tracer #(
-      .FPU       (FPU),
-      .PULP_ZFINX(PULP_ZFINX)
+      .FPU  (FPU),
+      .ZFINX(ZFINX)
   ) tracer_i (
       .clk_i(cv32e40p_wrapper_i.core_i.clk_i),  // always-running clock for tracing
       .rst_n(cv32e40p_wrapper_i.core_i.rst_ni),
@@ -213,8 +213,8 @@ module cv32e40p_tb_wrapper
 
 `ifdef CV32E40P_RVFI
   cv32e40p_rvfi #(
-      .FPU(FPU),
-      .PULP_ZFINX(PULP_ZFINX)
+      .FPU  (FPU),
+      .ZFINX(ZFINX)
   ) rvfi_i (
       .clk_i (cv32e40p_wrapper_i.core_i.clk_i),
       .rst_ni(cv32e40p_wrapper_i.core_i.rst_ni),
@@ -389,8 +389,8 @@ module cv32e40p_tb_wrapper
   );
 
   bind cv32e40p_rvfi: rvfi_i cv32e40p_rvfi_trace #(
-      .FPU(FPU),
-      .PULP_ZFINX(PULP_ZFINX)
+      .FPU  (FPU),
+      .ZFINX(ZFINX)
   ) cv32e40p_tracer_i (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -425,7 +425,7 @@ module cv32e40p_tb_wrapper
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),
-      .ZFINX           (PULP_ZFINX),
+      .ZFINX           (ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
   ) cv32e40p_wrapper_i (
       .clk_i (clk_i),

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -46,8 +46,8 @@
 module cv32e40p_tb_wrapper
   import cv32e40p_pkg::*;
 #(
-    parameter PULP_XPULP       = 0, // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. p.elw)
-    parameter PULP_CLUSTER = 0,  // PULP Cluster interface (incl. p.elw)
+    parameter COREV_PULP = 0, // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. cv.elw)
+    parameter COREV_CLUSTER = 0,  // PULP Cluster interface (incl. cv.elw)
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication computing lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion computing lanes pipeline registers number
@@ -58,7 +58,7 @@ module cv32e40p_tb_wrapper
     input logic clk_i,
     input logic rst_ni,
 
-    input logic pulp_clock_en_i,  // PULP clock enable (only used if PULP_CLUSTER = 1)
+    input logic pulp_clock_en_i,  // PULP clock enable (only used if COREV_CLUSTER = 1)
     input logic scan_cg_en_i,  // Enable all clock gates for testing
 
     // Core ID, Cluster ID, debug mode halt address and boot address are considered more or less static
@@ -109,7 +109,7 @@ module cv32e40p_tb_wrapper
       cv32e40p_prefetch_controller_sva
       #(
       .DEPTH          (DEPTH),
-      .PULP_XPULP     (PULP_XPULP),
+      .COREV_PULP     (COREV_PULP),
       .PULP_OBI       (PULP_OBI),
       .FIFO_ADDR_DEPTH(FIFO_ADDR_DEPTH)
   ) prefetch_controller_sva (.*);
@@ -118,8 +118,8 @@ module cv32e40p_tb_wrapper
 
 `ifdef CV32E40P_CORE_LOG
   cv32e40p_core_log #(
-      .PULP_XPULP      (PULP_XPULP),
-      .PULP_CLUSTER    (PULP_CLUSTER),
+      .COREV_PULP      (COREV_PULP),
+      .COREV_CLUSTER   (COREV_CLUSTER),
       .FPU             (FPU),
       .ZFINX           (ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
@@ -427,8 +427,8 @@ module cv32e40p_tb_wrapper
 `endif
   // Instantiate the Core and the optinal FPU
   cv32e40p_top #(
-      .PULP_XPULP      (PULP_XPULP),
-      .PULP_CLUSTER    (PULP_CLUSTER),
+      .COREV_PULP      (COREV_PULP),
+      .COREV_CLUSTER   (COREV_CLUSTER),
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -326,8 +326,10 @@ module cv32e40p_tb_wrapper
       .csr_we_i       (cv32e40p_top_i.core_i.cs_registers_i.csr_we_int),
       .csr_wdata_int_i(cv32e40p_top_i.core_i.cs_registers_i.csr_wdata_int),
 
-      .csr_mstatus_n_i(cv32e40p_top_i.core_i.cs_registers_i.mstatus_n),
-      .csr_mstatus_q_i(cv32e40p_top_i.core_i.cs_registers_i.mstatus_q),
+      .csr_mstatus_n_i   (cv32e40p_top_i.core_i.cs_registers_i.mstatus_n),
+      .csr_mstatus_q_i   (cv32e40p_top_i.core_i.cs_registers_i.mstatus_q),
+      .csr_mstatus_fs_n_i(cv32e40p_top_i.core_i.cs_registers_i.mstatus_fs_n),
+      .csr_mstatus_fs_q_i(cv32e40p_top_i.core_i.cs_registers_i.mstatus_fs_q),
 
       .csr_misa_n_i(cv32e40p_top_i.core_i.cs_registers_i.MISA_VALUE),  // WARL
       .csr_misa_q_i(cv32e40p_top_i.core_i.cs_registers_i.MISA_VALUE),

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -425,7 +425,7 @@ module cv32e40p_tb_wrapper
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),
-      .PULP_ZFINX      (PULP_ZFINX),
+      .ZFINX           (PULP_ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
   ) cv32e40p_wrapper_i (
       .clk_i (clk_i),

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -37,6 +37,9 @@
 
 `ifdef CV32E40P_RVFI
 `include "cv32e40p_rvfi.sv"
+`endif
+
+`ifdef CV32E40P_RVFI_TRACE_EXECUTION
 `include "cv32e40p_rvfi_trace.sv"
 `endif
 
@@ -387,7 +390,9 @@ module cv32e40p_tb_wrapper
       .csr_fcsr_frm_n_i   (cv32e40p_wrapper_i.core_i.cs_registers_i.frm_n),
       .csr_fcsr_frm_q_i   (cv32e40p_wrapper_i.core_i.cs_registers_i.frm_q)
   );
+`endif
 
+`ifdef CV32E40P_RVFI_TRACE_EXECUTION
   bind cv32e40p_rvfi: rvfi_i cv32e40p_rvfi_trace #(
       .FPU  (FPU),
       .ZFINX(ZFINX)

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-// Wrapper for a cv32e40p, containing cv32e40p_wrapper, and rvfi_tracer
+// Wrapper for a cv32e40p, containing cv32e40p_top, and rvfi_tracer
 //
 // Contributors: Davide Schiavone, OpenHW Group <davide@openhwgroup.org>
 //               Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>
@@ -105,7 +105,7 @@ module cv32e40p_tb_wrapper
 
   // RTL Assertions
   bind cv32e40p_prefetch_controller:
-      cv32e40p_wrapper_i.core_i.if_stage_i.prefetch_buffer_i.prefetch_controller_i
+      cv32e40p_top_i.core_i.if_stage_i.prefetch_buffer_i.prefetch_controller_i
       cv32e40p_prefetch_controller_sva
       #(
       .DEPTH          (DEPTH),
@@ -124,22 +124,22 @@ module cv32e40p_tb_wrapper
       .ZFINX           (ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
   ) core_log_i (
-      .clk_i             (cv32e40p_wrapper_i.core_i.id_stage_i.clk),
-      .is_decoding_i     (cv32e40p_wrapper_i.core_i.id_stage_i.is_decoding_o),
-      .illegal_insn_dec_i(cv32e40p_wrapper_i.core_i.id_stage_i.illegal_insn_dec),
-      .hart_id_i         (cv32e40p_wrapper_i.core_i.hart_id_i),
-      .pc_id_i           (cv32e40p_wrapper_i.core_i.pc_id)
+      .clk_i             (cv32e40p_top_i.core_i.id_stage_i.clk),
+      .is_decoding_i     (cv32e40p_top_i.core_i.id_stage_i.is_decoding_o),
+      .illegal_insn_dec_i(cv32e40p_top_i.core_i.id_stage_i.illegal_insn_dec),
+      .hart_id_i         (cv32e40p_top_i.core_i.hart_id_i),
+      .pc_id_i           (cv32e40p_top_i.core_i.pc_id)
   );
 `endif  // CV32E40P_CORE_LOG
 
 `ifdef CV32E40P_APU_TRACE
   cv32e40p_apu_tracer apu_tracer_i (
-      .clk_i       (cv32e40p_wrapper_i.core_i.rst_ni),
-      .rst_n       (cv32e40p_wrapper_i.core_i.clk_i),
-      .hart_id_i   (cv32e40p_wrapper_i.core_i.hart_id_i),
-      .apu_valid_i (cv32e40p_wrapper_i.core_i.ex_stage_i.apu_valid),
-      .apu_waddr_i (cv32e40p_wrapper_i.core_i.ex_stage_i.apu_waddr),
-      .apu_result_i(cv32e40p_wrapper_i.core_i.ex_stage_i.apu_result)
+      .clk_i       (cv32e40p_top_i.core_i.rst_ni),
+      .rst_n       (cv32e40p_top_i.core_i.clk_i),
+      .hart_id_i   (cv32e40p_top_i.core_i.hart_id_i),
+      .apu_valid_i (cv32e40p_top_i.core_i.ex_stage_i.apu_valid),
+      .apu_waddr_i (cv32e40p_top_i.core_i.ex_stage_i.apu_waddr),
+      .apu_result_i(cv32e40p_top_i.core_i.ex_stage_i.apu_result)
   );
 `endif
 
@@ -148,69 +148,69 @@ module cv32e40p_tb_wrapper
       .FPU  (FPU),
       .ZFINX(ZFINX)
   ) tracer_i (
-      .clk_i(cv32e40p_wrapper_i.core_i.clk_i),  // always-running clock for tracing
-      .rst_n(cv32e40p_wrapper_i.core_i.rst_ni),
+      .clk_i(cv32e40p_top_i.core_i.clk_i),  // always-running clock for tracing
+      .rst_n(cv32e40p_top_i.core_i.rst_ni),
 
-      .hart_id_i(cv32e40p_wrapper_i.core_i.hart_id_i),
+      .hart_id_i(cv32e40p_top_i.core_i.hart_id_i),
 
-      .pc                (cv32e40p_wrapper_i.core_i.id_stage_i.pc_id_i),
-      .instr             (cv32e40p_wrapper_i.core_i.id_stage_i.instr),
-      .controller_state_i(cv32e40p_wrapper_i.core_i.id_stage_i.controller_i.ctrl_fsm_cs),
-      .compressed        (cv32e40p_wrapper_i.core_i.id_stage_i.is_compressed_i),
-      .id_valid          (cv32e40p_wrapper_i.core_i.id_stage_i.id_valid_o),
-      .is_decoding       (cv32e40p_wrapper_i.core_i.id_stage_i.is_decoding_o),
-      .is_illegal        (cv32e40p_wrapper_i.core_i.id_stage_i.illegal_insn_dec),
-      .trigger_match     (cv32e40p_wrapper_i.core_i.id_stage_i.trigger_match_i),
-      .rs1_value         (cv32e40p_wrapper_i.core_i.id_stage_i.operand_a_fw_id),
-      .rs2_value         (cv32e40p_wrapper_i.core_i.id_stage_i.operand_b_fw_id),
-      .rs3_value         (cv32e40p_wrapper_i.core_i.id_stage_i.alu_operand_c),
-      .rs2_value_vec     (cv32e40p_wrapper_i.core_i.id_stage_i.alu_operand_b),
+      .pc                (cv32e40p_top_i.core_i.id_stage_i.pc_id_i),
+      .instr             (cv32e40p_top_i.core_i.id_stage_i.instr),
+      .controller_state_i(cv32e40p_top_i.core_i.id_stage_i.controller_i.ctrl_fsm_cs),
+      .compressed        (cv32e40p_top_i.core_i.id_stage_i.is_compressed_i),
+      .id_valid          (cv32e40p_top_i.core_i.id_stage_i.id_valid_o),
+      .is_decoding       (cv32e40p_top_i.core_i.id_stage_i.is_decoding_o),
+      .is_illegal        (cv32e40p_top_i.core_i.id_stage_i.illegal_insn_dec),
+      .trigger_match     (cv32e40p_top_i.core_i.id_stage_i.trigger_match_i),
+      .rs1_value         (cv32e40p_top_i.core_i.id_stage_i.operand_a_fw_id),
+      .rs2_value         (cv32e40p_top_i.core_i.id_stage_i.operand_b_fw_id),
+      .rs3_value         (cv32e40p_top_i.core_i.id_stage_i.alu_operand_c),
+      .rs2_value_vec     (cv32e40p_top_i.core_i.id_stage_i.alu_operand_b),
 
-      .rs1_is_fp(cv32e40p_wrapper_i.core_i.id_stage_i.regfile_fp_a),
-      .rs2_is_fp(cv32e40p_wrapper_i.core_i.id_stage_i.regfile_fp_b),
-      .rs3_is_fp(cv32e40p_wrapper_i.core_i.id_stage_i.regfile_fp_c),
-      .rd_is_fp (cv32e40p_wrapper_i.core_i.id_stage_i.regfile_fp_d),
+      .rs1_is_fp(cv32e40p_top_i.core_i.id_stage_i.regfile_fp_a),
+      .rs2_is_fp(cv32e40p_top_i.core_i.id_stage_i.regfile_fp_b),
+      .rs3_is_fp(cv32e40p_top_i.core_i.id_stage_i.regfile_fp_c),
+      .rd_is_fp (cv32e40p_top_i.core_i.id_stage_i.regfile_fp_d),
 
-      .ex_valid    (cv32e40p_wrapper_i.core_i.ex_valid),
-      .ex_reg_addr (cv32e40p_wrapper_i.core_i.regfile_alu_waddr_fw),
-      .ex_reg_we   (cv32e40p_wrapper_i.core_i.regfile_alu_we_fw),
-      .ex_reg_wdata(cv32e40p_wrapper_i.core_i.regfile_alu_wdata_fw),
+      .ex_valid    (cv32e40p_top_i.core_i.ex_valid),
+      .ex_reg_addr (cv32e40p_top_i.core_i.regfile_alu_waddr_fw),
+      .ex_reg_we   (cv32e40p_top_i.core_i.regfile_alu_we_fw),
+      .ex_reg_wdata(cv32e40p_top_i.core_i.regfile_alu_wdata_fw),
 
-      .ex_data_addr   (cv32e40p_wrapper_i.core_i.data_addr_o),
-      .ex_data_req    (cv32e40p_wrapper_i.core_i.data_req_o),
-      .ex_data_gnt    (cv32e40p_wrapper_i.core_i.data_gnt_i),
-      .ex_data_we     (cv32e40p_wrapper_i.core_i.data_we_o),
-      .ex_data_wdata  (cv32e40p_wrapper_i.core_i.data_wdata_o),
-      .data_misaligned(cv32e40p_wrapper_i.core_i.data_misaligned),
+      .ex_data_addr   (cv32e40p_top_i.core_i.data_addr_o),
+      .ex_data_req    (cv32e40p_top_i.core_i.data_req_o),
+      .ex_data_gnt    (cv32e40p_top_i.core_i.data_gnt_i),
+      .ex_data_we     (cv32e40p_top_i.core_i.data_we_o),
+      .ex_data_wdata  (cv32e40p_top_i.core_i.data_wdata_o),
+      .data_misaligned(cv32e40p_top_i.core_i.data_misaligned),
 
-      .ebrk_insn(cv32e40p_wrapper_i.core_i.id_stage_i.ebrk_insn_dec),
-      .debug_mode(cv32e40p_wrapper_i.core_i.debug_mode),
-      .ebrk_force_debug_mode (cv32e40p_wrapper_i.core_i.id_stage_i.controller_i.ebrk_force_debug_mode),
+      .ebrk_insn(cv32e40p_top_i.core_i.id_stage_i.ebrk_insn_dec),
+      .debug_mode(cv32e40p_top_i.core_i.debug_mode),
+      .ebrk_force_debug_mode(cv32e40p_top_i.core_i.id_stage_i.controller_i.ebrk_force_debug_mode),
 
-      .wb_bypass(cv32e40p_wrapper_i.core_i.ex_stage_i.branch_in_ex_i),
+      .wb_bypass(cv32e40p_top_i.core_i.ex_stage_i.branch_in_ex_i),
 
-      .wb_valid    (cv32e40p_wrapper_i.core_i.wb_valid),
-      .wb_reg_addr (cv32e40p_wrapper_i.core_i.regfile_waddr_fw_wb_o),
-      .wb_reg_we   (cv32e40p_wrapper_i.core_i.regfile_we_wb),
-      .wb_reg_wdata(cv32e40p_wrapper_i.core_i.regfile_wdata),
+      .wb_valid    (cv32e40p_top_i.core_i.wb_valid),
+      .wb_reg_addr (cv32e40p_top_i.core_i.regfile_waddr_fw_wb_o),
+      .wb_reg_we   (cv32e40p_top_i.core_i.regfile_we_wb),
+      .wb_reg_wdata(cv32e40p_top_i.core_i.regfile_wdata),
 
-      .imm_u_type       (cv32e40p_wrapper_i.core_i.id_stage_i.imm_u_type),
-      .imm_uj_type      (cv32e40p_wrapper_i.core_i.id_stage_i.imm_uj_type),
-      .imm_i_type       (cv32e40p_wrapper_i.core_i.id_stage_i.imm_i_type),
-      .imm_iz_type      (cv32e40p_wrapper_i.core_i.id_stage_i.imm_iz_type[11:0]),
-      .imm_z_type       (cv32e40p_wrapper_i.core_i.id_stage_i.imm_z_type),
-      .imm_s_type       (cv32e40p_wrapper_i.core_i.id_stage_i.imm_s_type),
-      .imm_sb_type      (cv32e40p_wrapper_i.core_i.id_stage_i.imm_sb_type),
-      .imm_s2_type      (cv32e40p_wrapper_i.core_i.id_stage_i.imm_s2_type),
-      .imm_s3_type      (cv32e40p_wrapper_i.core_i.id_stage_i.imm_s3_type),
-      .imm_vs_type      (cv32e40p_wrapper_i.core_i.id_stage_i.imm_vs_type),
-      .imm_vu_type      (cv32e40p_wrapper_i.core_i.id_stage_i.imm_vu_type),
-      .imm_shuffle_type (cv32e40p_wrapper_i.core_i.id_stage_i.imm_shuffle_type),
-      .imm_clip_type    (cv32e40p_wrapper_i.core_i.id_stage_i.instr[11:7]),
-      .apu_en_i         (cv32e40p_wrapper_i.apu_req),
-      .apu_singlecycle_i(cv32e40p_wrapper_i.core_i.ex_stage_i.apu_singlecycle),
-      .apu_multicycle_i (cv32e40p_wrapper_i.core_i.ex_stage_i.apu_multicycle),
-      .apu_rvalid_i     (cv32e40p_wrapper_i.apu_rvalid)
+      .imm_u_type       (cv32e40p_top_i.core_i.id_stage_i.imm_u_type),
+      .imm_uj_type      (cv32e40p_top_i.core_i.id_stage_i.imm_uj_type),
+      .imm_i_type       (cv32e40p_top_i.core_i.id_stage_i.imm_i_type),
+      .imm_iz_type      (cv32e40p_top_i.core_i.id_stage_i.imm_iz_type[11:0]),
+      .imm_z_type       (cv32e40p_top_i.core_i.id_stage_i.imm_z_type),
+      .imm_s_type       (cv32e40p_top_i.core_i.id_stage_i.imm_s_type),
+      .imm_sb_type      (cv32e40p_top_i.core_i.id_stage_i.imm_sb_type),
+      .imm_s2_type      (cv32e40p_top_i.core_i.id_stage_i.imm_s2_type),
+      .imm_s3_type      (cv32e40p_top_i.core_i.id_stage_i.imm_s3_type),
+      .imm_vs_type      (cv32e40p_top_i.core_i.id_stage_i.imm_vs_type),
+      .imm_vu_type      (cv32e40p_top_i.core_i.id_stage_i.imm_vu_type),
+      .imm_shuffle_type (cv32e40p_top_i.core_i.id_stage_i.imm_shuffle_type),
+      .imm_clip_type    (cv32e40p_top_i.core_i.id_stage_i.instr[11:7]),
+      .apu_en_i         (cv32e40p_top_i.apu_req),
+      .apu_singlecycle_i(cv32e40p_top_i.core_i.ex_stage_i.apu_singlecycle),
+      .apu_multicycle_i (cv32e40p_top_i.core_i.ex_stage_i.apu_multicycle),
+      .apu_rvalid_i     (cv32e40p_top_i.apu_rvalid)
   );
 `endif
 
@@ -219,176 +219,176 @@ module cv32e40p_tb_wrapper
       .FPU  (FPU),
       .ZFINX(ZFINX)
   ) rvfi_i (
-      .clk_i (cv32e40p_wrapper_i.core_i.clk_i),
-      .rst_ni(cv32e40p_wrapper_i.core_i.rst_ni),
+      .clk_i (cv32e40p_top_i.core_i.clk_i),
+      .rst_ni(cv32e40p_top_i.core_i.rst_ni),
 
-      .is_decoding_i    (cv32e40p_wrapper_i.core_i.id_stage_i.is_decoding_o),
-      .is_illegal_i     (cv32e40p_wrapper_i.core_i.id_stage_i.illegal_insn_dec),
-      .trigger_match_i  (cv32e40p_wrapper_i.core_i.id_stage_i.trigger_match_i),
-      .data_misaligned_i(cv32e40p_wrapper_i.core_i.data_misaligned),
-      .lsu_data_we_ex_i (cv32e40p_wrapper_i.core_i.data_we_ex),
-      .debug_mode_i     (cv32e40p_wrapper_i.core_i.debug_mode),
-      .debug_cause_i    (cv32e40p_wrapper_i.core_i.debug_cause),
+      .is_decoding_i    (cv32e40p_top_i.core_i.id_stage_i.is_decoding_o),
+      .is_illegal_i     (cv32e40p_top_i.core_i.id_stage_i.illegal_insn_dec),
+      .trigger_match_i  (cv32e40p_top_i.core_i.id_stage_i.trigger_match_i),
+      .data_misaligned_i(cv32e40p_top_i.core_i.data_misaligned),
+      .lsu_data_we_ex_i (cv32e40p_top_i.core_i.data_we_ex),
+      .debug_mode_i     (cv32e40p_top_i.core_i.debug_mode),
+      .debug_cause_i    (cv32e40p_top_i.core_i.debug_cause),
       //// Instr IF probes ////
-      .instr_req_i      (cv32e40p_wrapper_i.core_i.instr_req_o),
-      .instr_grant_i    (cv32e40p_wrapper_i.core_i.instr_gnt_i),
-      .instr_rvalid_i   (cv32e40p_wrapper_i.core_i.instr_rvalid_i),
-      .prefetch_req_i   (cv32e40p_wrapper_i.core_i.instr_req_int),
-      .pc_set_i         (cv32e40p_wrapper_i.core_i.pc_set),
+      .instr_req_i      (cv32e40p_top_i.core_i.instr_req_o),
+      .instr_grant_i    (cv32e40p_top_i.core_i.instr_gnt_i),
+      .instr_rvalid_i   (cv32e40p_top_i.core_i.instr_rvalid_i),
+      .prefetch_req_i   (cv32e40p_top_i.core_i.instr_req_int),
+      .pc_set_i         (cv32e40p_top_i.core_i.pc_set),
 
-      .instr_valid_id_i    (cv32e40p_wrapper_i.core_i.instr_valid_id),
-      .instr_rdata_id_i    (cv32e40p_wrapper_i.core_i.instr_rdata_id),
-      .is_fetch_failed_id_i(cv32e40p_wrapper_i.core_i.is_fetch_failed_id),
-      .instr_req_int_i     (cv32e40p_wrapper_i.core_i.instr_req_int),
-      .clear_instr_valid_i (cv32e40p_wrapper_i.core_i.clear_instr_valid),
+      .instr_valid_id_i    (cv32e40p_top_i.core_i.instr_valid_id),
+      .instr_rdata_id_i    (cv32e40p_top_i.core_i.instr_rdata_id),
+      .is_fetch_failed_id_i(cv32e40p_top_i.core_i.is_fetch_failed_id),
+      .instr_req_int_i     (cv32e40p_top_i.core_i.instr_req_int),
+      .clear_instr_valid_i (cv32e40p_top_i.core_i.clear_instr_valid),
       //// IF probes ////
-      .instr_valid_if_i    (cv32e40p_wrapper_i.core_i.if_stage_i.instr_valid),
-      .if_valid_i          (cv32e40p_wrapper_i.core_i.if_stage_i.if_valid),
-      .if_ready_i          (cv32e40p_wrapper_i.core_i.if_stage_i.if_ready),
-      .instr_if_i          (cv32e40p_wrapper_i.core_i.if_stage_i.instr_aligned),
-      .pc_if_i             (cv32e40p_wrapper_i.core_i.pc_if),
+      .instr_valid_if_i    (cv32e40p_top_i.core_i.if_stage_i.instr_valid),
+      .if_valid_i          (cv32e40p_top_i.core_i.if_stage_i.if_valid),
+      .if_ready_i          (cv32e40p_top_i.core_i.if_stage_i.if_ready),
+      .instr_if_i          (cv32e40p_top_i.core_i.if_stage_i.instr_aligned),
+      .pc_if_i             (cv32e40p_top_i.core_i.pc_if),
       //// ID probes ////
-      .pc_id_i             (cv32e40p_wrapper_i.core_i.id_stage_i.pc_id_i),
-      .id_valid_i          (cv32e40p_wrapper_i.core_i.id_stage_i.id_valid_o),
-      .id_ready_i          (cv32e40p_wrapper_i.core_i.id_stage_i.id_ready_o),
+      .pc_id_i             (cv32e40p_top_i.core_i.id_stage_i.pc_id_i),
+      .id_valid_i          (cv32e40p_top_i.core_i.id_stage_i.id_valid_o),
+      .id_ready_i          (cv32e40p_top_i.core_i.id_stage_i.id_ready_o),
 
-      .rs1_addr_id_i     (cv32e40p_wrapper_i.core_i.id_stage_i.regfile_addr_ra_id),
-      .rs2_addr_id_i     (cv32e40p_wrapper_i.core_i.id_stage_i.regfile_addr_rb_id),
-      .operand_a_fw_id_i (cv32e40p_wrapper_i.core_i.id_stage_i.operand_a_fw_id),
-      .operand_b_fw_id_i (cv32e40p_wrapper_i.core_i.id_stage_i.operand_b_fw_id),
-      // .instr         (cv32e40p_wrapper_i.core_i.id_stage_i.instr     ),
-      .is_compressed_id_i(cv32e40p_wrapper_i.core_i.id_stage_i.is_compressed_i),
-      .ebrk_insn_dec_i   (cv32e40p_wrapper_i.core_i.id_stage_i.ebrk_insn_dec),
-      .csr_cause_i       (cv32e40p_wrapper_i.core_i.csr_cause),
-      .debug_csr_save_i  (cv32e40p_wrapper_i.core_i.debug_csr_save),
+      .rs1_addr_id_i     (cv32e40p_top_i.core_i.id_stage_i.regfile_addr_ra_id),
+      .rs2_addr_id_i     (cv32e40p_top_i.core_i.id_stage_i.regfile_addr_rb_id),
+      .operand_a_fw_id_i (cv32e40p_top_i.core_i.id_stage_i.operand_a_fw_id),
+      .operand_b_fw_id_i (cv32e40p_top_i.core_i.id_stage_i.operand_b_fw_id),
+      // .instr         (cv32e40p_top_i.core_i.id_stage_i.instr     ),
+      .is_compressed_id_i(cv32e40p_top_i.core_i.id_stage_i.is_compressed_i),
+      .ebrk_insn_dec_i   (cv32e40p_top_i.core_i.id_stage_i.ebrk_insn_dec),
+      .csr_cause_i       (cv32e40p_top_i.core_i.csr_cause),
+      .debug_csr_save_i  (cv32e40p_top_i.core_i.debug_csr_save),
 
       //// EX probes ////
-      .ex_valid_i    (cv32e40p_wrapper_i.core_i.ex_valid),
-      .ex_ready_i    (cv32e40p_wrapper_i.core_i.ex_ready),
-      .ex_reg_addr_i (cv32e40p_wrapper_i.core_i.regfile_alu_waddr_fw),
-      .ex_reg_we_i   (cv32e40p_wrapper_i.core_i.regfile_alu_we_fw),
-      .ex_reg_wdata_i(cv32e40p_wrapper_i.core_i.regfile_alu_wdata_fw),
-      .apu_en_ex_i   (cv32e40p_wrapper_i.core_i.apu_en_ex),
+      .ex_valid_i    (cv32e40p_top_i.core_i.ex_valid),
+      .ex_ready_i    (cv32e40p_top_i.core_i.ex_ready),
+      .ex_reg_addr_i (cv32e40p_top_i.core_i.regfile_alu_waddr_fw),
+      .ex_reg_we_i   (cv32e40p_top_i.core_i.regfile_alu_we_fw),
+      .ex_reg_wdata_i(cv32e40p_top_i.core_i.regfile_alu_wdata_fw),
+      .apu_en_ex_i   (cv32e40p_top_i.core_i.apu_en_ex),
 
-      // .rf_we_alu_i    (cv32e40p_wrapper_i.core_i.id_stage_i.regfile_alu_we_fw_i),
-      // .rf_addr_alu_i  (cv32e40p_wrapper_i.core_i.id_stage_i.regfile_alu_waddr_fw_i),
-      // .rf_wdata_alu_i (cv32e40p_wrapper_i.core_i.id_stage_i.regfile_alu_wdata_fw_i),
+      // .rf_we_alu_i    (cv32e40p_top_i.core_i.id_stage_i.regfile_alu_we_fw_i),
+      // .rf_addr_alu_i  (cv32e40p_top_i.core_i.id_stage_i.regfile_alu_waddr_fw_i),
+      // .rf_wdata_alu_i (cv32e40p_top_i.core_i.id_stage_i.regfile_alu_wdata_fw_i),
 
       //// WB probes ////
-      .wb_valid_i(cv32e40p_wrapper_i.core_i.wb_valid),
+      .wb_valid_i(cv32e40p_top_i.core_i.wb_valid),
 
       //// LSU probes ////
-      .data_we_ex_i        (cv32e40p_wrapper_i.core_i.data_we_ex),
-      .data_atop_ex_i      (cv32e40p_wrapper_i.core_i.data_atop_ex),
-      .data_type_ex_i      (cv32e40p_wrapper_i.core_i.data_type_ex),
-      .alu_operand_c_ex_i  (cv32e40p_wrapper_i.core_i.alu_operand_c_ex),
-      .data_reg_offset_ex_i(cv32e40p_wrapper_i.core_i.data_reg_offset_ex),
-      .data_load_event_ex_i(cv32e40p_wrapper_i.core_i.data_load_event_ex),
-      .data_sign_ext_ex_i  (cv32e40p_wrapper_i.core_i.data_sign_ext_ex),
-      .lsu_rdata_i         (cv32e40p_wrapper_i.core_i.lsu_rdata),
-      .data_req_ex_i       (cv32e40p_wrapper_i.core_i.data_req_ex),
-      .alu_operand_a_ex_i  (cv32e40p_wrapper_i.core_i.alu_operand_a_ex),
-      .alu_operand_b_ex_i  (cv32e40p_wrapper_i.core_i.alu_operand_b_ex),
-      .useincr_addr_ex_i   (cv32e40p_wrapper_i.core_i.useincr_addr_ex),
-      .data_misaligned_ex_i(cv32e40p_wrapper_i.core_i.data_misaligned_ex),
-      .p_elw_start_i       (cv32e40p_wrapper_i.core_i.p_elw_start),
-      .p_elw_finish_i      (cv32e40p_wrapper_i.core_i.p_elw_finish),
-      .lsu_ready_ex_i      (cv32e40p_wrapper_i.core_i.lsu_ready_ex),
-      .lsu_ready_wb_i      (cv32e40p_wrapper_i.core_i.lsu_ready_wb),
+      .data_we_ex_i        (cv32e40p_top_i.core_i.data_we_ex),
+      .data_atop_ex_i      (cv32e40p_top_i.core_i.data_atop_ex),
+      .data_type_ex_i      (cv32e40p_top_i.core_i.data_type_ex),
+      .alu_operand_c_ex_i  (cv32e40p_top_i.core_i.alu_operand_c_ex),
+      .data_reg_offset_ex_i(cv32e40p_top_i.core_i.data_reg_offset_ex),
+      .data_load_event_ex_i(cv32e40p_top_i.core_i.data_load_event_ex),
+      .data_sign_ext_ex_i  (cv32e40p_top_i.core_i.data_sign_ext_ex),
+      .lsu_rdata_i         (cv32e40p_top_i.core_i.lsu_rdata),
+      .data_req_ex_i       (cv32e40p_top_i.core_i.data_req_ex),
+      .alu_operand_a_ex_i  (cv32e40p_top_i.core_i.alu_operand_a_ex),
+      .alu_operand_b_ex_i  (cv32e40p_top_i.core_i.alu_operand_b_ex),
+      .useincr_addr_ex_i   (cv32e40p_top_i.core_i.useincr_addr_ex),
+      .data_misaligned_ex_i(cv32e40p_top_i.core_i.data_misaligned_ex),
+      .p_elw_start_i       (cv32e40p_top_i.core_i.p_elw_start),
+      .p_elw_finish_i      (cv32e40p_top_i.core_i.p_elw_finish),
+      .lsu_ready_ex_i      (cv32e40p_top_i.core_i.lsu_ready_ex),
+      .lsu_ready_wb_i      (cv32e40p_top_i.core_i.lsu_ready_wb),
 
-      .data_req_pmp_i(cv32e40p_wrapper_i.core_i.data_req_pmp),
-      .data_gnt_pmp_i(cv32e40p_wrapper_i.core_i.data_gnt_pmp),
-      .data_rvalid_i(cv32e40p_wrapper_i.core_i.data_rvalid_i),
-      .data_err_pmp_i(cv32e40p_wrapper_i.core_i.data_err_pmp),
-      .data_addr_pmp_i(cv32e40p_wrapper_i.core_i.data_addr_pmp),
-      .data_we_i(cv32e40p_wrapper_i.core_i.data_we_o),
-      .data_atop_i(cv32e40p_wrapper_i.core_i.data_atop_o),
-      .data_be_i(cv32e40p_wrapper_i.core_i.data_be_o),
-      .data_wdata_i(cv32e40p_wrapper_i.core_i.data_wdata_o),
-      .data_rdata_i(cv32e40p_wrapper_i.core_i.data_rdata_i),
+      .data_req_pmp_i(cv32e40p_top_i.core_i.data_req_pmp),
+      .data_gnt_pmp_i(cv32e40p_top_i.core_i.data_gnt_pmp),
+      .data_rvalid_i(cv32e40p_top_i.core_i.data_rvalid_i),
+      .data_err_pmp_i(cv32e40p_top_i.core_i.data_err_pmp),
+      .data_addr_pmp_i(cv32e40p_top_i.core_i.data_addr_pmp),
+      .data_we_i(cv32e40p_top_i.core_i.data_we_o),
+      .data_atop_i(cv32e40p_top_i.core_i.data_atop_o),
+      .data_be_i(cv32e40p_top_i.core_i.data_be_o),
+      .data_wdata_i(cv32e40p_top_i.core_i.data_wdata_o),
+      .data_rdata_i(cv32e40p_top_i.core_i.data_rdata_i),
       // Register writes
-      .rf_we_wb_i(cv32e40p_wrapper_i.core_i.id_stage_i.regfile_we_wb_i),
-      .rf_addr_wb_i(cv32e40p_wrapper_i.core_i.id_stage_i.regfile_waddr_wb_i),
-      .rf_wdata_wb_i(cv32e40p_wrapper_i.core_i.id_stage_i.regfile_wdata_wb_i),
+      .rf_we_wb_i(cv32e40p_top_i.core_i.id_stage_i.regfile_we_wb_i),
+      .rf_addr_wb_i(cv32e40p_top_i.core_i.id_stage_i.regfile_waddr_wb_i),
+      .rf_wdata_wb_i(cv32e40p_top_i.core_i.id_stage_i.regfile_wdata_wb_i),
 
       // APU
-      .apu_req_i   (cv32e40p_wrapper_i.core_i.apu_req_o),
-      .apu_gnt_i   (cv32e40p_wrapper_i.core_i.apu_gnt_i),
-      .apu_rvalid_i(cv32e40p_wrapper_i.core_i.apu_rvalid_i),
+      .apu_req_i   (cv32e40p_top_i.core_i.apu_req_o),
+      .apu_gnt_i   (cv32e40p_top_i.core_i.apu_gnt_i),
+      .apu_rvalid_i(cv32e40p_top_i.core_i.apu_rvalid_i),
 
       // Controller FSM probes
-      .ctrl_fsm_cs_i(cv32e40p_wrapper_i.core_i.id_stage_i.controller_i.ctrl_fsm_cs),
-      .pc_mux_i     (cv32e40p_wrapper_i.core_i.id_stage_i.controller_i.pc_mux_o),
-      .exc_pc_mux_i (cv32e40p_wrapper_i.core_i.id_stage_i.controller_i.exc_pc_mux_o),
+      .ctrl_fsm_cs_i(cv32e40p_top_i.core_i.id_stage_i.controller_i.ctrl_fsm_cs),
+      .pc_mux_i     (cv32e40p_top_i.core_i.id_stage_i.controller_i.pc_mux_o),
+      .exc_pc_mux_i (cv32e40p_top_i.core_i.id_stage_i.controller_i.exc_pc_mux_o),
 
       //CSR
-      .csr_addr_i     (cv32e40p_wrapper_i.core_i.cs_registers_i.csr_addr_i),
-      .csr_we_i       (cv32e40p_wrapper_i.core_i.cs_registers_i.csr_we_int),
-      .csr_wdata_int_i(cv32e40p_wrapper_i.core_i.cs_registers_i.csr_wdata_int),
+      .csr_addr_i     (cv32e40p_top_i.core_i.cs_registers_i.csr_addr_i),
+      .csr_we_i       (cv32e40p_top_i.core_i.cs_registers_i.csr_we_int),
+      .csr_wdata_int_i(cv32e40p_top_i.core_i.cs_registers_i.csr_wdata_int),
 
-      .csr_mstatus_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mstatus_n),
-      .csr_mstatus_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mstatus_q),
+      .csr_mstatus_n_i(cv32e40p_top_i.core_i.cs_registers_i.mstatus_n),
+      .csr_mstatus_q_i(cv32e40p_top_i.core_i.cs_registers_i.mstatus_q),
 
-      .csr_misa_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.MISA_VALUE),  // WARL
-      .csr_misa_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.MISA_VALUE),
+      .csr_misa_n_i(cv32e40p_top_i.core_i.cs_registers_i.MISA_VALUE),  // WARL
+      .csr_misa_q_i(cv32e40p_top_i.core_i.cs_registers_i.MISA_VALUE),
 
-      .csr_tdata1_n_i           (cv32e40p_wrapper_i.core_i.cs_registers_i.tmatch_control_rdata),//csr_wdata_int                                   ),
-      .csr_tdata1_q_i           (cv32e40p_wrapper_i.core_i.cs_registers_i.tmatch_control_rdata),//gen_trigger_regs.tmatch_control_exec_q          ),
-      .csr_tdata1_we_i(cv32e40p_wrapper_i.core_i.cs_registers_i.gen_trigger_regs.tmatch_control_we),
+      .csr_tdata1_n_i           (cv32e40p_top_i.core_i.cs_registers_i.tmatch_control_rdata),//csr_wdata_int                                   ),
+      .csr_tdata1_q_i           (cv32e40p_top_i.core_i.cs_registers_i.tmatch_control_rdata),//gen_trigger_regs.tmatch_control_exec_q          ),
+      .csr_tdata1_we_i(cv32e40p_top_i.core_i.cs_registers_i.gen_trigger_regs.tmatch_control_we),
 
-      .csr_tinfo_n_i({16'h0, cv32e40p_wrapper_i.core_i.cs_registers_i.tinfo_types}),
-      .csr_tinfo_q_i({16'h0, cv32e40p_wrapper_i.core_i.cs_registers_i.tinfo_types}),
+      .csr_tinfo_n_i({16'h0, cv32e40p_top_i.core_i.cs_registers_i.tinfo_types}),
+      .csr_tinfo_q_i({16'h0, cv32e40p_top_i.core_i.cs_registers_i.tinfo_types}),
 
-      .csr_mie_n_i       (cv32e40p_wrapper_i.core_i.cs_registers_i.mie_n),
-      .csr_mie_q_i       (cv32e40p_wrapper_i.core_i.cs_registers_i.mie_q),
-      .csr_mie_we_i      (cv32e40p_wrapper_i.core_i.cs_registers_i.csr_mie_we),
-      .csr_mtvec_n_i     (cv32e40p_wrapper_i.core_i.cs_registers_i.mtvec_n),
-      .csr_mtvec_q_i     (cv32e40p_wrapper_i.core_i.cs_registers_i.mtvec_q),
-      .csr_mtvec_mode_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mtvec_mode_n),
-      .csr_mtvec_mode_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mtvec_mode_q),
+      .csr_mie_n_i       (cv32e40p_top_i.core_i.cs_registers_i.mie_n),
+      .csr_mie_q_i       (cv32e40p_top_i.core_i.cs_registers_i.mie_q),
+      .csr_mie_we_i      (cv32e40p_top_i.core_i.cs_registers_i.csr_mie_we),
+      .csr_mtvec_n_i     (cv32e40p_top_i.core_i.cs_registers_i.mtvec_n),
+      .csr_mtvec_q_i     (cv32e40p_top_i.core_i.cs_registers_i.mtvec_q),
+      .csr_mtvec_mode_n_i(cv32e40p_top_i.core_i.cs_registers_i.mtvec_mode_n),
+      .csr_mtvec_mode_q_i(cv32e40p_top_i.core_i.cs_registers_i.mtvec_mode_q),
 
-      .csr_mcountinhibit_q_i (cv32e40p_wrapper_i.core_i.cs_registers_i.mcountinhibit_q),
-      .csr_mcountinhibit_n_i (cv32e40p_wrapper_i.core_i.cs_registers_i.mcountinhibit_n),
-      .csr_mcountinhibit_we_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mcountinhibit_we),
+      .csr_mcountinhibit_q_i (cv32e40p_top_i.core_i.cs_registers_i.mcountinhibit_q),
+      .csr_mcountinhibit_n_i (cv32e40p_top_i.core_i.cs_registers_i.mcountinhibit_n),
+      .csr_mcountinhibit_we_i(cv32e40p_top_i.core_i.cs_registers_i.mcountinhibit_we),
 
-      .csr_mscratch_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mscratch_q),
-      .csr_mscratch_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mscratch_n),
-      .csr_mepc_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mepc_q),
-      .csr_mepc_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mepc_n),
-      .csr_mcause_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mcause_q),
-      .csr_mcause_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mcause_n),
-      .csr_mip_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mip),
-      .csr_mip_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mip),
-      .csr_mip_we_i('0),  //(cv32e40p_wrapper_i.core_i.cs_registers_i.mip)
+      .csr_mscratch_q_i(cv32e40p_top_i.core_i.cs_registers_i.mscratch_q),
+      .csr_mscratch_n_i(cv32e40p_top_i.core_i.cs_registers_i.mscratch_n),
+      .csr_mepc_q_i(cv32e40p_top_i.core_i.cs_registers_i.mepc_q),
+      .csr_mepc_n_i(cv32e40p_top_i.core_i.cs_registers_i.mepc_n),
+      .csr_mcause_q_i(cv32e40p_top_i.core_i.cs_registers_i.mcause_q),
+      .csr_mcause_n_i(cv32e40p_top_i.core_i.cs_registers_i.mcause_n),
+      .csr_mip_n_i(cv32e40p_top_i.core_i.cs_registers_i.mip),
+      .csr_mip_q_i(cv32e40p_top_i.core_i.cs_registers_i.mip),
+      .csr_mip_we_i('0),  //(cv32e40p_top_i.core_i.cs_registers_i.mip)
 
 
-      .csr_dcsr_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.dcsr_q),
-      .csr_dcsr_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.dcsr_n),
+      .csr_dcsr_q_i(cv32e40p_top_i.core_i.cs_registers_i.dcsr_q),
+      .csr_dcsr_n_i(cv32e40p_top_i.core_i.cs_registers_i.dcsr_n),
 
-      .csr_dpc_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.depc_n),
-      .csr_dpc_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.depc_q),
-      .csr_dpc_we_i('0),  //cv32e40p_wrapper_i.core_i.cs_registers_i.),
-      .csr_dscratch0_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.dscratch0_n),
-      .csr_dscratch0_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.dscratch0_q),
-      .csr_dscratch0_we_i('0),  //cv32e40p_wrapper_i.core_i.cs_registers_i.),
+      .csr_dpc_n_i(cv32e40p_top_i.core_i.cs_registers_i.depc_n),
+      .csr_dpc_q_i(cv32e40p_top_i.core_i.cs_registers_i.depc_q),
+      .csr_dpc_we_i('0),  //cv32e40p_top_i.core_i.cs_registers_i.),
+      .csr_dscratch0_n_i(cv32e40p_top_i.core_i.cs_registers_i.dscratch0_n),
+      .csr_dscratch0_q_i(cv32e40p_top_i.core_i.cs_registers_i.dscratch0_q),
+      .csr_dscratch0_we_i('0),  //cv32e40p_top_i.core_i.cs_registers_i.),
 
-      .csr_dscratch1_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.dscratch1_n),
-      .csr_dscratch1_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.dscratch1_q),
-      .csr_dscratch1_we_i('0),  //cv32e40p_wrapper_i.core_i.cs_registers_i.),
+      .csr_dscratch1_n_i(cv32e40p_top_i.core_i.cs_registers_i.dscratch1_n),
+      .csr_dscratch1_q_i(cv32e40p_top_i.core_i.cs_registers_i.dscratch1_q),
+      .csr_dscratch1_we_i('0),  //cv32e40p_top_i.core_i.cs_registers_i.),
 
-      .csr_mhpmcounter_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.mhpmcounter_q),
-      .csr_mhpmcounter_write_lower_i (cv32e40p_wrapper_i.core_i.cs_registers_i.mhpmcounter_write_lower                     ),
-      .csr_mhpmcounter_write_upper_i (cv32e40p_wrapper_i.core_i.cs_registers_i.mhpmcounter_write_upper                     ),
+      .csr_mhpmcounter_q_i          (cv32e40p_top_i.core_i.cs_registers_i.mhpmcounter_q),
+      .csr_mhpmcounter_write_lower_i(cv32e40p_top_i.core_i.cs_registers_i.mhpmcounter_write_lower),
+      .csr_mhpmcounter_write_upper_i(cv32e40p_top_i.core_i.cs_registers_i.mhpmcounter_write_upper),
 
       .csr_mvendorid_i({
         MVENDORID_BANK, MVENDORID_OFFSET
       }),  //TODO: get this from the design instead of the pkg
       .csr_marchid_i(MARCHID),  //TODO: get this from the design instead of the pkg
 
-      .csr_fcsr_fflags_n_i(cv32e40p_wrapper_i.core_i.cs_registers_i.fflags_n),
-      .csr_fcsr_fflags_q_i(cv32e40p_wrapper_i.core_i.cs_registers_i.fflags_q),
-      .csr_fcsr_frm_n_i   (cv32e40p_wrapper_i.core_i.cs_registers_i.frm_n),
-      .csr_fcsr_frm_q_i   (cv32e40p_wrapper_i.core_i.cs_registers_i.frm_q)
+      .csr_fcsr_fflags_n_i(cv32e40p_top_i.core_i.cs_registers_i.fflags_n),
+      .csr_fcsr_fflags_q_i(cv32e40p_top_i.core_i.cs_registers_i.fflags_q),
+      .csr_fcsr_frm_n_i   (cv32e40p_top_i.core_i.cs_registers_i.frm_n),
+      .csr_fcsr_frm_q_i   (cv32e40p_top_i.core_i.cs_registers_i.frm_q)
   );
 `endif
 
@@ -399,9 +399,9 @@ module cv32e40p_tb_wrapper
   ) cv32e40p_tracer_i (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .hart_id_i(cv32e40p_wrapper_i.core_i.hart_id_i),
+      .hart_id_i(cv32e40p_top_i.core_i.hart_id_i),
 
-      .imm_s3_type(cv32e40p_wrapper_i.core_i.id_stage_i.imm_s3_type),
+      .imm_s3_type(cv32e40p_top_i.core_i.id_stage_i.imm_s3_type),
 
       .rvfi_valid(rvfi_valid),
       .rvfi_insn(rvfi_insn),
@@ -424,7 +424,7 @@ module cv32e40p_tb_wrapper
   );
 `endif
   // Instantiate the Core and the optinal FPU
-  cv32e40p_wrapper #(
+  cv32e40p_top #(
       .PULP_XPULP      (PULP_XPULP),
       .PULP_CLUSTER    (PULP_CLUSTER),
       .FPU             (FPU),
@@ -432,7 +432,7 @@ module cv32e40p_tb_wrapper
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),
       .ZFINX           (ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
-  ) cv32e40p_wrapper_i (
+  ) cv32e40p_top_i (
       .clk_i (clk_i),
       .rst_ni(rst_ni),
 

--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -28,8 +28,8 @@ module cv32e40p_tracer
   import cv32e40p_pkg::*;
   import uvm_pkg::*;
 #(
-    parameter FPU = 0,
-    parameter PULP_ZFINX = 0
+    parameter FPU   = 0,
+    parameter ZFINX = 0
 ) (
     // Clock and Reset
     input logic clk_i,

--- a/bhv/include/cv32e40p_rvfi_pkg.sv
+++ b/bhv/include/cv32e40p_rvfi_pkg.sv
@@ -23,39 +23,6 @@
 package cv32e40p_rvfi_pkg;
   import cv32e40p_pkg::*;
 
-  typedef struct packed {
-    logic [31:28] xdebugver;
-    logic [27:16] zero2;
-    logic ebreakm;
-    logic zero1;
-    logic ebreaks;
-    logic ebreaku;
-    logic stepie;
-    logic stopcount;
-    logic stoptime;
-    logic [8:6] cause;
-    logic zero0;
-    logic mprven;
-    logic nmip;
-    logic step;
-    PrivLvl_t prv;
-  } Dcsr_t;
-
-  typedef struct packed {
-    logic uie;
-    // logic sie;      - unimplemented, hardwired to '0
-    // logic hie;      - unimplemented, hardwired to '0
-    logic mie;
-    logic upie;
-    // logic spie;     - unimplemented, hardwired to '0
-    // logic hpie;     - unimplemented, hardwired to '0
-    logic mpie;
-    // logic spp;      - unimplemented, hardwired to '0
-    // logic[1:0] hpp; - unimplemented, hardwired to '0
-    PrivLvl_t mpp;
-    logic mprv;
-  } Status_t;
-
   // RVFI only supports MHPMCOUNTER_WIDTH == 64
   parameter MHPMCOUNTER_WORDS = MHPMCOUNTER_WIDTH / 32;
 

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -188,6 +188,8 @@ typedef struct {
     logic jvt_we;
     Status_t mstatus_n;
     Status_t mstatus_q;
+    FS_t mstatus_fs_n;
+    FS_t mstatus_fs_q;
     logic [31:0] mstatus_full_n;
     logic [31:0] mstatus_full_q;
 
@@ -491,10 +493,22 @@ task monitor_pipeline();
     r_pipe_freeze_trace.csr.jvt_we = csr_jvt_we_i;
     r_pipe_freeze_trace.csr.mstatus_n = csr_mstatus_n_i;
     r_pipe_freeze_trace.csr.mstatus_q = csr_mstatus_q_i;
+    r_pipe_freeze_trace.csr.mstatus_fs_n = csr_mstatus_fs_n_i;
+    r_pipe_freeze_trace.csr.mstatus_fs_q = csr_mstatus_fs_q_i;
 
-    r_pipe_freeze_trace.csr.mstatus_full_q[31:18] = '0;
+    if (FPU == 1 && ZFINX == 0) begin
+      r_pipe_freeze_trace.csr.mstatus_full_q[31] = (r_pipe_freeze_trace.csr.mstatus_fs_q == FS_DIRTY) ? 1'b1 : 1'b0;
+    end else begin
+      r_pipe_freeze_trace.csr.mstatus_full_q[31] = '0;
+    end
+    r_pipe_freeze_trace.csr.mstatus_full_q[30:18] = '0;
     r_pipe_freeze_trace.csr.mstatus_full_q[17] = r_pipe_freeze_trace.csr.mstatus_q.mprv;
-    r_pipe_freeze_trace.csr.mstatus_full_q[16:13] = '0;
+    r_pipe_freeze_trace.csr.mstatus_full_q[16:15] = '0;
+    if (FPU == 1 && ZFINX == 0) begin
+      r_pipe_freeze_trace.csr.mstatus_full_q[14:13] = r_pipe_freeze_trace.csr.mstatus_fs_q;
+    end else begin
+      r_pipe_freeze_trace.csr.mstatus_full_q[14:13] = '0;
+    end
     r_pipe_freeze_trace.csr.mstatus_full_q[12:11] = r_pipe_freeze_trace.csr.mstatus_q.mpp;
     r_pipe_freeze_trace.csr.mstatus_full_q[10:8] = '0;
     r_pipe_freeze_trace.csr.mstatus_full_q[7] = r_pipe_freeze_trace.csr.mstatus_q.mpie;
@@ -504,9 +518,19 @@ task monitor_pipeline();
     r_pipe_freeze_trace.csr.mstatus_full_q[2:1] = '0;
     r_pipe_freeze_trace.csr.mstatus_full_q[0] = r_pipe_freeze_trace.csr.mstatus_q.uie;
 
-    r_pipe_freeze_trace.csr.mstatus_full_n[31:18] = '0;
+    if (FPU == 1 && ZFINX == 0) begin
+      r_pipe_freeze_trace.csr.mstatus_full_n[31] = (r_pipe_freeze_trace.csr.mstatus_fs_n == FS_DIRTY) ? 1'b1 : 1'b0;
+    end else begin
+      r_pipe_freeze_trace.csr.mstatus_full_n[31] = '0;
+    end
+    r_pipe_freeze_trace.csr.mstatus_full_n[30:18] = '0;
     r_pipe_freeze_trace.csr.mstatus_full_n[17] = r_pipe_freeze_trace.csr.mstatus_n.mprv;
-    r_pipe_freeze_trace.csr.mstatus_full_n[16:13] = '0;
+    r_pipe_freeze_trace.csr.mstatus_full_n[16:15] = '0;
+    if (FPU == 1 && ZFINX == 0) begin
+      r_pipe_freeze_trace.csr.mstatus_full_n[14:13] = r_pipe_freeze_trace.csr.mstatus_fs_n;
+    end else begin
+      r_pipe_freeze_trace.csr.mstatus_full_n[14:13] = '0;
+    end
     r_pipe_freeze_trace.csr.mstatus_full_n[12:11] = r_pipe_freeze_trace.csr.mstatus_n.mpp;
     r_pipe_freeze_trace.csr.mstatus_full_n[10:8] = '0;
     r_pipe_freeze_trace.csr.mstatus_full_n[7] = r_pipe_freeze_trace.csr.mstatus_n.mpie;

--- a/cv32e40p_fpu_manifest.flist
+++ b/cv32e40p_fpu_manifest.flist
@@ -80,7 +80,7 @@ ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_divsqrt_multi.sv
 ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_top.sv
 ${DESIGN_RTL_DIR}/cv32e40p_fp_wrapper.sv
 
-${DESIGN_RTL_DIR}/cv32e40p_wrapper.sv
+${DESIGN_RTL_DIR}/cv32e40p_top.sv
 
 ${DESIGN_RTL_DIR}/../bhv/cv32e40p_sim_clock_gate.sv
 ${DESIGN_RTL_DIR}/../bhv/include/cv32e40p_tracer_pkg.sv

--- a/cv32e40p_manifest.flist
+++ b/cv32e40p_manifest.flist
@@ -56,7 +56,7 @@ ${DESIGN_RTL_DIR}/cv32e40p_prefetch_controller.sv
 ${DESIGN_RTL_DIR}/cv32e40p_sleep_unit.sv
 ${DESIGN_RTL_DIR}/cv32e40p_core.sv
 
-${DESIGN_RTL_DIR}/cv32e40p_wrapper.sv
+${DESIGN_RTL_DIR}/cv32e40p_top.sv
 
 ${DESIGN_RTL_DIR}/../bhv/cv32e40p_sim_clock_gate.sv
 ${DESIGN_RTL_DIR}/../bhv/include/cv32e40p_tracer_pkg.sv

--- a/example_tb/core/cv32e40p_tb_subsystem.sv
+++ b/example_tb/core/cv32e40p_tb_subsystem.sv
@@ -18,7 +18,7 @@ module cv32e40p_tb_subsystem #(
     parameter PULP_XPULP = 0,
     parameter PULP_CLUSTER = 0,
     parameter FPU = 0,
-    parameter PULP_ZFINX = 0,
+    parameter ZFINX = 0,
     parameter NUM_MHPMCOUNTERS = 1,
     parameter DM_HALTADDRESS = 32'h1A110800
 ) (
@@ -87,7 +87,7 @@ module cv32e40p_tb_subsystem #(
       .PULP_XPULP      (PULP_XPULP),
       .PULP_CLUSTER    (PULP_CLUSTER),
       .FPU             (FPU),
-      .PULP_ZFINX      (PULP_ZFINX),
+      .ZFINX           (ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
   ) wrapper_i (
       .clk_i (clk_i),

--- a/example_tb/core/tb_top.sv
+++ b/example_tb/core/tb_top.sv
@@ -20,7 +20,7 @@ module tb_top #(
     parameter PULP_XPULP = 0,
     parameter PULP_CLUSTER = 0,
     parameter FPU = 0,
-    parameter PULP_ZFINX = 0,
+    parameter ZFINX = 0,
     parameter NUM_MHPMCOUNTERS = 1,
     parameter DM_HALTADDRESS = 32'h1A110800
 );
@@ -149,7 +149,7 @@ module tb_top #(
       .PULP_XPULP       (PULP_XPULP),
       .PULP_CLUSTER     (PULP_CLUSTER),
       .FPU              (FPU),
-      .PULP_ZFINX       (PULP_ZFINX),
+      .ZFINX            (ZFINX),
       .NUM_MHPMCOUNTERS (NUM_MHPMCOUNTERS),
       .DM_HALTADDRESS   (DM_HALTADDRESS)
   ) wrapper_i (

--- a/rtl/cv32e40p_compressed_decoder.sv
+++ b/rtl/cv32e40p_compressed_decoder.sv
@@ -25,8 +25,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_compressed_decoder #(
-    parameter FPU        = 0,
-    parameter PULP_ZFINX = 0
+    parameter FPU   = 0,
+    parameter ZFINX = 0
 ) (
     input  logic [31:0] instr_i,
     output logic [31:0] instr_o,
@@ -73,7 +73,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b001: begin
             // c.fld -> fld rd', imm(rs1')
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               // instr_i[12:10]-> offset[5:3],  instr_i[6:5]-> offset[7:6]
               instr_o = {
                 4'b0,
@@ -109,7 +109,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b011: begin
             // c.flw -> flw rd', imm(rs1')
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               instr_o = {
                 5'b0,
                 instr_i[5],
@@ -128,7 +128,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b101: begin
             // c.fsd -> fsd rs2', imm(rs1')
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               // instr_i[12:10] -> offset[5:3], instr_i[6:5] -> offset[7:6]
               instr_o = {
                 4'b0,
@@ -166,7 +166,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b111: begin
             // c.fsw -> fsw rs2', imm(rs1')
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               instr_o = {
                 5'b0,
                 instr_i[5],
@@ -452,7 +452,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b001: begin
             // c.fldsp -> fld rd, imm(x2)
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               // instr_i[6:5] -> offset[4:3], instr_i[4:2] -> offset[8:6], instr_i[12] -> offset[5]
               instr_o = {
                 3'b0,
@@ -486,7 +486,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b011: begin
             // c.flwsp -> flw rd, imm(x2)
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               instr_o = {
                 4'b0,
                 instr_i[3:2],
@@ -540,7 +540,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b101: begin
             // c.fsdsp -> fsd rs2, imm(x2)
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               // instr_i[12:10] -> offset[5:3], instr_i[9:7] -> offset[8:6]
               instr_o = {
                 3'b0,
@@ -572,7 +572,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b111: begin
             // c.fswsp -> fsw rs2, imm(x2)
-            if (FPU == 1 && PULP_ZFINX == 0)
+            if (FPU == 1 && ZFINX == 0)
               instr_o = {
                 4'b0,
                 instr_i[8:7],

--- a/rtl/cv32e40p_compressed_decoder.sv
+++ b/rtl/cv32e40p_compressed_decoder.sv
@@ -25,7 +25,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_compressed_decoder #(
-    parameter FPU = 0
+    parameter FPU        = 0,
+    parameter PULP_ZFINX = 0
 ) (
     input  logic [31:0] instr_i,
     output logic [31:0] instr_o,
@@ -72,7 +73,8 @@ module cv32e40p_compressed_decoder #(
 
           3'b001: begin
             // c.fld -> fld rd', imm(rs1')
-            if (FPU == 1)  // instr_i[12:10]-> offset[5:3],  instr_i[6:5]-> offset[7:6]
+            if (FPU == 1 && PULP_ZFINX == 0)
+              // instr_i[12:10]-> offset[5:3],  instr_i[6:5]-> offset[7:6]
               instr_o = {
                 4'b0,
                 instr_i[6:5],
@@ -107,7 +109,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b011: begin
             // c.flw -> flw rd', imm(rs1')
-            if (FPU == 1)
+            if (FPU == 1 && PULP_ZFINX == 0)
               instr_o = {
                 5'b0,
                 instr_i[5],
@@ -126,7 +128,8 @@ module cv32e40p_compressed_decoder #(
 
           3'b101: begin
             // c.fsd -> fsd rs2', imm(rs1')
-            if (FPU == 1)  // instr_i[12:10] -> offset[5:3], instr_i[6:5] -> offset[7:6]
+            if (FPU == 1 && PULP_ZFINX == 0)
+              // instr_i[12:10] -> offset[5:3], instr_i[6:5] -> offset[7:6]
               instr_o = {
                 4'b0,
                 instr_i[6:5],
@@ -163,7 +166,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b111: begin
             // c.fsw -> fsw rs2', imm(rs1')
-            if (FPU == 1)
+            if (FPU == 1 && PULP_ZFINX == 0)
               instr_o = {
                 5'b0,
                 instr_i[5],
@@ -449,7 +452,8 @@ module cv32e40p_compressed_decoder #(
 
           3'b001: begin
             // c.fldsp -> fld rd, imm(x2)
-            if (FPU==1) // instr_i[6:5] -> offset[4:3], instr_i[4:2] -> offset[8:6], instr_i[12] -> offset[5]
+            if (FPU == 1 && PULP_ZFINX == 0)
+              // instr_i[6:5] -> offset[4:3], instr_i[4:2] -> offset[8:6], instr_i[12] -> offset[5]
               instr_o = {
                 3'b0,
                 instr_i[4:2],
@@ -482,7 +486,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b011: begin
             // c.flwsp -> flw rd, imm(x2)
-            if (FPU == 1)
+            if (FPU == 1 && PULP_ZFINX == 0)
               instr_o = {
                 4'b0,
                 instr_i[3:2],
@@ -536,7 +540,8 @@ module cv32e40p_compressed_decoder #(
 
           3'b101: begin
             // c.fsdsp -> fsd rs2, imm(x2)
-            if (FPU == 1)  // instr_i[12:10] -> offset[5:3], instr_i[9:7] -> offset[8:6]
+            if (FPU == 1 && PULP_ZFINX == 0)
+              // instr_i[12:10] -> offset[5:3], instr_i[9:7] -> offset[8:6]
               instr_o = {
                 3'b0,
                 instr_i[9:7],
@@ -567,7 +572,7 @@ module cv32e40p_compressed_decoder #(
 
           3'b111: begin
             // c.fswsp -> fsw rs2, imm(x2)
-            if (FPU == 1)
+            if (FPU == 1 && PULP_ZFINX == 0)
               instr_o = {
                 4'b0,
                 instr_i[8:7],

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -197,6 +197,7 @@ module cv32e40p_core
   logic                                     mult_clpx_img_ex;
 
   // FPU
+  logic                                     fs_off;
   logic        [            C_RM-1:0]       frm_csr;
   logic        [         C_FFLAG-1:0]       fflags_csr;
   logic                                     fflags_we;
@@ -608,7 +609,8 @@ module cv32e40p_core
       .mult_clpx_img_ex_o  (mult_clpx_img_ex),  // from ID to EX stage
 
       // FPU
-      .frm_i(frm_csr),
+      .fs_off_i(fs_off),
+      .frm_i   (frm_csr),
 
       // APU
       .apu_en_ex_o      (apu_en_ex),
@@ -953,6 +955,7 @@ module cv32e40p_core
       .csr_op_i        (csr_op),
       .csr_rdata_o     (csr_rdata),
 
+      .fs_off_o   (fs_off),
       .frm_o      (frm_csr),
       .fflags_i   (fflags_csr),
       .fflags_we_i(fflags_we),

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -36,7 +36,7 @@ module cv32e40p_core
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion lanes pipeline registers number
-    parameter PULP_ZFINX = 0,  // Float-in-General Purpose registers
+    parameter ZFINX = 0,  // Float-in-General Purpose registers
     parameter NUM_MHPMCOUNTERS = 1
 ) (
     // Clock and Reset
@@ -421,7 +421,7 @@ module cv32e40p_core
       .PULP_OBI   (PULP_OBI),
       .PULP_SECURE(PULP_SECURE),
       .FPU        (FPU),
-      .PULP_ZFINX (PULP_ZFINX)
+      .ZFINX      (ZFINX)
   ) if_stage_i (
       .clk  (clk),
       .rst_n(rst_ni),
@@ -516,7 +516,7 @@ module cv32e40p_core
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),
-      .PULP_ZFINX      (PULP_ZFINX),
+      .ZFINX           (ZFINX),
       .APU_NARGS_CPU   (APU_NARGS_CPU),
       .APU_WOP_CPU     (APU_WOP_CPU),
       .APU_NDSFLAGS_CPU(APU_NDSFLAGS_CPU),
@@ -929,7 +929,7 @@ module cv32e40p_core
       .N_HWLP          (N_HWLP),
       .A_EXTENSION     (A_EXTENSION),
       .FPU             (FPU),
-      .PULP_ZFINX      (PULP_ZFINX),
+      .ZFINX           (ZFINX),
       .APU             (APU),
       .PULP_SECURE     (PULP_SECURE),
       .USE_PMP         (USE_PMP),
@@ -1126,23 +1126,6 @@ module cv32e40p_core
   //----------------------------------------------------------------------------
   // Assertions
   //----------------------------------------------------------------------------
-
-  // PULP_XPULP, PULP_CLUSTER, FPU, PULP_ZFINX
-  always_ff @(posedge rst_ni) begin
-    if (PULP_XPULP) begin
-      $warning(
-          "PULP_XPULP == 1 has not been verified yet and non-backward compatible RTL fixes are expected (see https://github.com/openhwgroup/cv32e40p/issues/452)");
-    end
-    if (PULP_CLUSTER) begin
-      $warning("PULP_CLUSTER == 1 has not been verified yet");
-    end
-    if (FPU) begin
-      $warning("FPU == 1 has not been verified yet");
-    end
-    if (PULP_ZFINX) begin
-      $warning("PULP_ZFINX == 1 has not been verified yet");
-    end
-  end
 
   generate
     if (!PULP_CLUSTER) begin : gen_no_pulp_cluster_assertions

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -31,8 +31,8 @@
 module cv32e40p_core
   import cv32e40p_apu_core_pkg::*;
 #(
-    parameter PULP_XPULP          =  0,                   // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. p.elw)
-    parameter PULP_CLUSTER = 0,  // PULP Cluster interface (incl. p.elw)
+    parameter COREV_PULP =  0,  // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. cv.elw)
+    parameter COREV_CLUSTER = 0,  // PULP Cluster interface (incl. cv.elw)
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion lanes pipeline registers number
@@ -43,7 +43,7 @@ module cv32e40p_core
     input logic clk_i,
     input logic rst_ni,
 
-    input logic pulp_clock_en_i,  // PULP clock enable (only used if PULP_CLUSTER = 1)
+    input logic pulp_clock_en_i,  // PULP clock enable (only used if COREV_CLUSTER = 1)
     input logic scan_cg_en_i,  // Enable all clock gates for testing
 
     // Core ID, Cluster ID, debug mode halt address and boot address are considered more or less static
@@ -164,7 +164,7 @@ module cv32e40p_core
   logic               lsu_busy;
   logic               apu_busy;
 
-  logic        [31:0] pc_ex;  // PC of last executed branch or p.elw
+  logic        [31:0] pc_ex;  // PC of last executed branch or cv.elw
 
   // ALU Control
   logic               alu_en_ex;
@@ -260,8 +260,8 @@ module cv32e40p_core
   logic               data_load_event_ex;
   logic               data_misaligned_ex;
 
-  logic               p_elw_start;  // Start of p.elw load (when data_req_o is sent)
-  logic               p_elw_finish;  // Finish of p.elw load (when data_rvalid_i is received)
+  logic               p_elw_start;  // Start of cv.elw load (when data_req_o is sent)
+  logic               p_elw_finish;  // Finish of cv.elw load (when data_rvalid_i is received)
 
   logic        [31:0] lsu_rdata;
 
@@ -376,7 +376,7 @@ module cv32e40p_core
   logic fetch_enable;
 
   cv32e40p_sleep_unit #(
-      .PULP_CLUSTER(PULP_CLUSTER)
+      .COREV_CLUSTER(COREV_CLUSTER)
   ) sleep_unit_i (
       // Clock, reset interface
       .clk_ungated_i(clk_i),  // Ungated clock
@@ -417,7 +417,7 @@ module cv32e40p_core
   //                                              //
   //////////////////////////////////////////////////
   cv32e40p_if_stage #(
-      .PULP_XPULP (PULP_XPULP),
+      .COREV_PULP (COREV_PULP),
       .PULP_OBI   (PULP_OBI),
       .PULP_SECURE(PULP_SECURE),
       .FPU        (FPU),
@@ -506,8 +506,8 @@ module cv32e40p_core
   //                                             //
   /////////////////////////////////////////////////
   cv32e40p_id_stage #(
-      .PULP_XPULP      (PULP_XPULP),
-      .PULP_CLUSTER    (PULP_CLUSTER),
+      .COREV_PULP      (COREV_PULP),
+      .COREV_CLUSTER   (COREV_CLUSTER),
       .N_HWLP          (N_HWLP),
       .PULP_SECURE     (PULP_SECURE),
       .USE_PMP         (USE_PMP),
@@ -935,8 +935,8 @@ module cv32e40p_core
       .USE_PMP         (USE_PMP),
       .N_PMP_ENTRIES   (N_PMP_ENTRIES),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS),
-      .PULP_XPULP      (PULP_XPULP),
-      .PULP_CLUSTER    (PULP_CLUSTER),
+      .COREV_PULP      (COREV_PULP),
+      .COREV_CLUSTER   (COREV_CLUSTER),
       .DEBUG_TRIGGER_EN(DEBUG_TRIGGER_EN)
   ) cs_registers_i (
       .clk  (clk),
@@ -1100,7 +1100,7 @@ module cv32e40p_core
   //----------------------------------------------------------------------------
 
   generate
-    if (PULP_CLUSTER) begin : gen_pulp_cluster_assumptions
+    if (COREV_CLUSTER) begin : gen_pulp_cluster_assumptions
 
       // Assumptions/requirements on the environment when pulp_clock_en_i = 0
       property p_env_req_0;
@@ -1128,7 +1128,7 @@ module cv32e40p_core
   //----------------------------------------------------------------------------
 
   generate
-    if (!PULP_CLUSTER) begin : gen_no_pulp_cluster_assertions
+    if (!COREV_CLUSTER) begin : gen_no_pulp_cluster_assertions
       // Check that a taken IRQ is actually enabled (e.g. that we do not react to an IRQ that was just disabled in MIE)
       property p_irq_enabled_0;
         @(posedge clk) disable iff (!rst_ni) (pc_set && (pc_mux_id == PC_EXCEPTION) && (exc_pc_mux_id == EXC_PC_IRQ)) |->
@@ -1150,7 +1150,7 @@ module cv32e40p_core
   endgenerate
 
   generate
-    if (!PULP_XPULP) begin : gen_no_pulp_xpulp_assertions
+    if (!COREV_PULP) begin : gen_no_pulp_xpulp_assertions
 
       // Illegal, ECALL, EBRK checks excluded for PULP due to other definition for for Hardware Loop
 

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -420,7 +420,8 @@ module cv32e40p_core
       .PULP_XPULP (PULP_XPULP),
       .PULP_OBI   (PULP_OBI),
       .PULP_SECURE(PULP_SECURE),
-      .FPU        (FPU)
+      .FPU        (FPU),
+      .PULP_ZFINX (PULP_ZFINX)
   ) if_stage_i (
       .clk  (clk),
       .rst_n(rst_ni),
@@ -928,6 +929,7 @@ module cv32e40p_core
       .N_HWLP          (N_HWLP),
       .A_EXTENSION     (A_EXTENSION),
       .FPU             (FPU),
+      .PULP_ZFINX      (PULP_ZFINX),
       .APU             (APU),
       .PULP_SECURE     (PULP_SECURE),
       .USE_PMP         (USE_PMP),

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -1130,36 +1130,36 @@ module cv32e40p_cs_registers
     endcase
   end
 
-  assign csr_rdata_o         = csr_rdata_int;
+  assign csr_rdata_o = csr_rdata_int;
 
   // directly output some registers
-  assign m_irq_enable_o      = mstatus_q.mie && !(dcsr_q.step && !dcsr_q.stepie);
-  assign u_irq_enable_o      = mstatus_q.uie && !(dcsr_q.step && !dcsr_q.stepie);
-  assign priv_lvl_o          = priv_lvl_q;
-  assign sec_lvl_o           = priv_lvl_q[0];
+  assign m_irq_enable_o = mstatus_q.mie && !(dcsr_q.step && !dcsr_q.stepie);
+  assign u_irq_enable_o = mstatus_q.uie && !(dcsr_q.step && !dcsr_q.stepie);
+  assign priv_lvl_o = priv_lvl_q;
+  assign sec_lvl_o = priv_lvl_q[0];
 
   // mstatus_fs_q = FS_OFF, FPU not enabled
-  assign fs_off_o            = (FPU == 1 && ZFINX == 0) ? (mstatus_fs_q == FS_OFF ? 1'b1 : 1'b0) : 1'b0;
-  assign frm_o               = (FPU == 1) ? frm_q : '0;
+  assign fs_off_o = (FPU == 1 && ZFINX == 0) ? (mstatus_fs_q == FS_OFF ? 1'b1 : 1'b0) : 1'b0;
+  assign frm_o = (FPU == 1) ? frm_q : '0;
 
-  assign mtvec_o             = mtvec_q;
-  assign utvec_o             = utvec_q;
-  assign mtvec_mode_o        = mtvec_mode_q;
-  assign utvec_mode_o        = utvec_mode_q;
+  assign mtvec_o = mtvec_q;
+  assign utvec_o = utvec_q;
+  assign mtvec_mode_o = mtvec_mode_q;
+  assign utvec_mode_o = utvec_mode_q;
 
-  assign mepc_o              = mepc_q;
-  assign uepc_o              = uepc_q;
+  assign mepc_o = mepc_q;
+  assign uepc_o = uepc_q;
 
-  assign mcounteren_o        = PULP_SECURE ? mcounteren_q : '0;
+  assign mcounteren_o = PULP_SECURE ? mcounteren_q : '0;
 
-  assign depc_o              = depc_q;
+  assign depc_o = depc_q;
 
-  assign pmp_addr_o          = pmp_reg_q.pmpaddr;
-  assign pmp_cfg_o           = pmp_reg_q.pmpcfg;
+  assign pmp_addr_o = pmp_reg_q.pmpaddr;
+  assign pmp_cfg_o = pmp_reg_q.pmpcfg;
 
   assign debug_single_step_o = dcsr_q.step;
-  assign debug_ebreakm_o     = dcsr_q.ebreakm;
-  assign debug_ebreaku_o     = dcsr_q.ebreaku;
+  assign debug_ebreakm_o = dcsr_q.ebreakm;
+  assign debug_ebreaku_o = dcsr_q.ebreaku;
 
   generate
     if (PULP_SECURE == 1) begin : gen_pmp_user

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -39,8 +39,8 @@ module cv32e40p_cs_registers
     parameter USE_PMP          = 0,
     parameter N_PMP_ENTRIES    = 16,
     parameter NUM_MHPMCOUNTERS = 1,
-    parameter PULP_XPULP       = 0,
-    parameter PULP_CLUSTER     = 0,
+    parameter COREV_PULP       = 0,
+    parameter COREV_CLUSTER    = 0,
     parameter DEBUG_TRIGGER_EN = 1
 ) (
     // Clock and Reset
@@ -172,7 +172,7 @@ module cv32e40p_cs_registers
   | (0 << 13)  // N - User level interrupts supported
   | (0 << 18)  // S - Supervisor mode implemented
   | (32'(PULP_SECURE) << 20)  // U - User mode implemented
-  | (32'(PULP_XPULP || PULP_CLUSTER) << 23)  // X - Non-standard extensions present
+  | (32'(COREV_PULP || COREV_CLUSTER) << 23)  // X - Non-standard extensions present
   | (32'(MXL) << 30);  // M-XLEN
 
   // This local parameter when set to 1 makes the Perf Counters not compliant with RISC-V
@@ -414,12 +414,12 @@ module cv32e40p_cs_registers
         csr_rdata_int = mhpmevent_q[csr_addr_i[4:0]];
 
         // hardware loops  (not official)
-        CSR_LPSTART0: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_start_i[0];
-        CSR_LPEND0:   csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_end_i[0];
-        CSR_LPCOUNT0: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_cnt_i[0];
-        CSR_LPSTART1: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_start_i[1];
-        CSR_LPEND1:   csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_end_i[1];
-        CSR_LPCOUNT1: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_cnt_i[1];
+        CSR_LPSTART0: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_start_i[0];
+        CSR_LPEND0:   csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_end_i[0];
+        CSR_LPCOUNT0: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_cnt_i[0];
+        CSR_LPSTART1: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_start_i[1];
+        CSR_LPEND1:   csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_end_i[1];
+        CSR_LPCOUNT1: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_cnt_i[1];
 
         // PMP config registers
         CSR_PMPCFG0: csr_rdata_int = USE_PMP ? pmp_reg_q.pmpcfg_packed[0] : '0;
@@ -439,14 +439,14 @@ module cv32e40p_cs_registers
         // utvec: user trap-handler base address
         CSR_UTVEC: csr_rdata_int = {utvec_q, 6'h0, utvec_mode_q};
         // duplicated mhartid: unique hardware thread id (not official)
-        CSR_UHARTID: csr_rdata_int = !PULP_XPULP ? 'b0 : hart_id_i;
+        CSR_UHARTID: csr_rdata_int = !COREV_PULP ? 'b0 : hart_id_i;
         // uepc: exception program counter
         CSR_UEPC: csr_rdata_int = uepc_q;
         // ucause: exception cause
         CSR_UCAUSE: csr_rdata_int = {ucause_q[5], 26'h0, ucause_q[4:0]};
 
         // current priv level (not official)
-        CSR_PRIVLV: csr_rdata_int = !PULP_XPULP ? 'b0 : {30'h0, priv_lvl_q};
+        CSR_PRIVLV: csr_rdata_int = !COREV_PULP ? 'b0 : {30'h0, priv_lvl_q};
 
         default: csr_rdata_int = '0;
       endcase
@@ -576,18 +576,18 @@ module cv32e40p_cs_registers
         csr_rdata_int = mhpmevent_q[csr_addr_i[4:0]];
 
         // hardware loops  (not official)
-        CSR_LPSTART0: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_start_i[0];
-        CSR_LPEND0:   csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_end_i[0];
-        CSR_LPCOUNT0: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_cnt_i[0];
-        CSR_LPSTART1: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_start_i[1];
-        CSR_LPEND1:   csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_end_i[1];
-        CSR_LPCOUNT1: csr_rdata_int = !PULP_XPULP ? 'b0 : hwlp_cnt_i[1];
+        CSR_LPSTART0: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_start_i[0];
+        CSR_LPEND0:   csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_end_i[0];
+        CSR_LPCOUNT0: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_cnt_i[0];
+        CSR_LPSTART1: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_start_i[1];
+        CSR_LPEND1:   csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_end_i[1];
+        CSR_LPCOUNT1: csr_rdata_int = !COREV_PULP ? 'b0 : hwlp_cnt_i[1];
 
         /* USER CSR */
         // dublicated mhartid: unique hardware thread id (not official)
-        CSR_UHARTID: csr_rdata_int = !PULP_XPULP ? 'b0 : hart_id_i;
+        CSR_UHARTID: csr_rdata_int = !COREV_PULP ? 'b0 : hart_id_i;
         // current priv level (not official)
-        CSR_PRIVLV: csr_rdata_int = !PULP_XPULP ? 'b0 : {30'h0, priv_lvl_q};
+        CSR_PRIVLV: csr_rdata_int = !COREV_PULP ? 'b0 : {30'h0, priv_lvl_q};
         default: csr_rdata_int = '0;
       endcase
     end
@@ -1324,7 +1324,7 @@ module cv32e40p_cs_registers
   assign hpm_events[8] = mhpmevent_branch_i;  // nr of branches (conditional)
   assign hpm_events[9] = mhpmevent_branch_taken_i;  // nr of taken branches (conditional)
   assign hpm_events[10] = mhpmevent_compressed_i;  // compressed instruction counter
-  assign hpm_events[11] = PULP_CLUSTER ? mhpmevent_pipe_stall_i : 1'b0;  // extra cycles from ELW
+  assign hpm_events[11] = COREV_CLUSTER ? mhpmevent_pipe_stall_i : 1'b0;  // extra cycles from ELW
   assign hpm_events[12] = !APU ? 1'b0 : apu_typeconflict_i && !apu_dep_i;
   assign hpm_events[13] = !APU ? 1'b0 : apu_contention_i;
   assign hpm_events[14] = !APU ? 1'b0 : apu_dep_i && !apu_contention_i;

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -34,7 +34,7 @@ module cv32e40p_cs_registers
     parameter APU              = 0,
     parameter A_EXTENSION      = 0,
     parameter FPU              = 0,
-    parameter PULP_ZFINX       = 0,
+    parameter ZFINX            = 0,
     parameter PULP_SECURE      = 0,
     parameter USE_PMP          = 0,
     parameter N_PMP_ENTRIES    = 16,
@@ -166,7 +166,7 @@ module cv32e40p_cs_registers
   | (1 << 2)  // C - Compressed extension
   | (0 << 3)  // D - Double precision floating-point extension
   | (0 << 4)  // E - RV32E base ISA
-  | (32'(FPU == 1 && PULP_ZFINX == 0) << 5)  // F - Single precision floating-point extension
+  | (32'(FPU == 1 && ZFINX == 0) << 5)  // F - Single precision floating-point extension
   | (1 << 8)  // I - RV32I/64I/128I base ISA
   | (1 << 12)  // M - Integer Multiply/Divide extension
   | (0 << 13)  // N - User level interrupts supported
@@ -504,11 +504,11 @@ module cv32e40p_cs_registers
         // mstatus: always M-mode, contains IE bit
         CSR_MSTATUS:
         csr_rdata_int = {
-          (FPU == 1 && PULP_ZFINX == 0) ? (mstatus_fs_q == FS_DIRTY ? 1'b1 : 1'b0) : 1'b0,
+          (FPU == 1 && ZFINX == 0) ? (mstatus_fs_q == FS_DIRTY ? 1'b1 : 1'b0) : 1'b0,
           13'b0,
           mstatus_q.mprv,
           2'b0,
-          (FPU == 1 && PULP_ZFINX == 0) ? mstatus_fs_q : FS_OFF,
+          (FPU == 1 && ZFINX == 0) ? mstatus_fs_q : FS_OFF,
           mstatus_q.mpp,
           3'b0,
           mstatus_q.mpie,
@@ -918,7 +918,7 @@ module cv32e40p_cs_registers
       if (FPU == 1) begin
         fflags_n = fflags_q;
         frm_n = frm_q;
-        if (PULP_ZFINX == 0) begin
+        if (ZFINX == 0) begin
           mstatus_fs_n = mstatus_fs_q;
           fcsr_update  = 1'b0;
         end
@@ -954,7 +954,7 @@ module cv32e40p_cs_registers
         if (FPU == 1) begin
           if (csr_we_int) begin
             fflags_n = csr_wdata_int[C_FFLAG-1:0];
-            if (PULP_ZFINX == 0) begin
+            if (ZFINX == 0) begin
               fcsr_update = 1'b1;
             end
           end
@@ -963,7 +963,7 @@ module cv32e40p_cs_registers
         if (FPU == 1) begin
           if (csr_we_int) begin
             frm_n = csr_wdata_int[C_RM-1:0];
-            if (PULP_ZFINX == 0) begin
+            if (ZFINX == 0) begin
               fcsr_update = 1'b1;
             end
           end
@@ -973,7 +973,7 @@ module cv32e40p_cs_registers
           if (csr_we_int) begin
             fflags_n = csr_wdata_int[C_FFLAG-1:0];
             frm_n    = csr_wdata_int[C_RM+C_FFLAG-1:C_FFLAG];
-            if (PULP_ZFINX == 0) begin
+            if (ZFINX == 0) begin
               fcsr_update = 1'b1;
             end
           end
@@ -990,7 +990,7 @@ module cv32e40p_cs_registers
               mpp: PrivLvl_t'(csr_wdata_int[MSTATUS_MPP_BIT_HIGH:MSTATUS_MPP_BIT_LOW]),
               mprv: csr_wdata_int[MSTATUS_MPRV_BIT]
           };
-          if (FPU == 1 && PULP_ZFINX == 0) begin
+          if (FPU == 1 && ZFINX == 0) begin
             mstatus_fs_n = FS_t'(csr_wdata_int[MSTATUS_FS_BIT_HIGH:MSTATUS_FS_BIT_LOW]);
           end
         end
@@ -1059,7 +1059,7 @@ module cv32e40p_cs_registers
           fflags_n = fflags_i | fflags_q;
         end
 
-        if (PULP_ZFINX == 0) begin
+        if (ZFINX == 0) begin
           // FPU Register File/Flags implicit update or modified by CSR instructions
           if (fflags_we_i || fcsr_update) begin
             mstatus_fs_n = FS_DIRTY;
@@ -1139,7 +1139,7 @@ module cv32e40p_cs_registers
   assign sec_lvl_o           = priv_lvl_q[0];
 
   // mstatus_fs_q = FS_OFF, FPU not enabled
-  assign fs_off_o            = (FPU == 1 && PULP_ZFINX == 0) ? (mstatus_fs_q == FS_OFF ? 1'b1 : 1'b0) : 1'b0;
+  assign fs_off_o            = (FPU == 1 && ZFINX == 0) ? (mstatus_fs_q == FS_OFF ? 1'b1 : 1'b0) : 1'b0;
   assign frm_o               = (FPU == 1) ? frm_q : '0;
 
   assign mtvec_o             = mtvec_q;
@@ -1212,7 +1212,7 @@ module cv32e40p_cs_registers
       if (FPU == 1) begin
         frm_q <= '0;
         fflags_q <= '0;
-        if (PULP_ZFINX == 0) begin
+        if (ZFINX == 0) begin
           mstatus_fs_q <= FS_OFF;
         end
       end
@@ -1245,7 +1245,7 @@ module cv32e40p_cs_registers
       if (FPU == 1) begin
         frm_q    <= frm_n;
         fflags_q <= fflags_n;
-        if (PULP_ZFINX == 0) begin
+        if (ZFINX == 0) begin
           mstatus_fs_q <= mstatus_fs_n;
         end
       end

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -1111,8 +1111,6 @@ module cv32e40p_cs_registers
     end
   end  //PULP_SECURE
 
-  assign hwlp_data_o = (PULP_XPULP) ? csr_wdata_int : '0;
-
   // CSR operation logic
   always_comb begin
     csr_wdata_int = csr_wdata_i;

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -180,47 +180,6 @@ module cv32e40p_cs_registers
   // but only HPMCOUNTERs (depending on NUM_MHPMCOUNTERS)
   localparam PULP_PERF_COUNTERS = 0;
 
-  // Floating Point State
-  typedef enum logic [1:0] {
-    FS_OFF     = 2'b00,
-    FS_INITIAL = 2'b01,
-    FS_CLEAN   = 2'b10,
-    FS_DIRTY   = 2'b11
-  } FS_t;
-
-  typedef struct packed {
-    logic uie;
-    // logic sie;      - unimplemented, hardwired to '0
-    // logic hie;      - unimplemented, hardwired to '0
-    logic mie;
-    logic upie;
-    // logic spie;     - unimplemented, hardwired to '0
-    // logic hpie;     - unimplemented, hardwired to '0
-    logic mpie;
-    // logic spp;      - unimplemented, hardwired to '0
-    // logic[1:0] hpp; - unimplemented, hardwired to '0
-    PrivLvl_t mpp;
-    logic mprv;
-  } Status_t;
-
-  typedef struct packed {
-    logic [31:28] xdebugver;
-    logic [27:16] zero2;
-    logic ebreakm;
-    logic zero1;
-    logic ebreaks;
-    logic ebreaku;
-    logic stepie;
-    logic stopcount;
-    logic stoptime;
-    logic [8:6] cause;
-    logic zero0;
-    logic mprven;
-    logic nmip;
-    logic step;
-    PrivLvl_t prv;
-  } Dcsr_t;
-
   typedef struct packed {
     logic [MAX_N_PMP_ENTRIES-1:0][31:0] pmpaddr;
     logic [MAX_N_PMP_CFG-1:0][31:0] pmpcfg_packed;

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -1010,7 +1010,7 @@ module cv32e40p_decoder
 
       // Floating Point arithmetic
       OPCODE_OP_FP: begin
-        if (FPU == 1 && fs_off_i == 1'b0) begin
+        if (FPU == 1 && (PULP_ZFINX == 1 || fs_off_i == 1'b0)) begin
 
           // using APU instead of ALU
           alu_en           = 1'b0;
@@ -1260,7 +1260,7 @@ module cv32e40p_decoder
               fp_op_group = NONCOMP;
               check_fprm  = 1'b0; // instruction encoded in rm, do the check here
               // fmv.x.fmt - FPR to GPR Move
-              if (instr_rdata_i[14:12] == 3'b000 || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
+              if ((PULP_ZFINX == 0 && instr_rdata_i[14:12] == 3'b000) || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
                 alu_op_b_mux_sel_o  = OP_B_REGA_OR_FWD; // set rs2 = rs1 so we can map FMV to SGNJ in the unit
                 fpu_op              = cv32e40p_fpu_pkg::SGNJ; // mapped to SGNJ-passthrough since no recoding
                 fpu_op_mod          = 1'b1;    // sign-extend result
@@ -1295,7 +1295,7 @@ module cv32e40p_decoder
               fp_op_group         = NONCOMP;
               fp_rnd_mode_o       = 3'b011;  // passthrough without checking nan-box
               check_fprm          = 1'b0; // instruction encoded in rm, do the check here
-              if (instr_rdata_i[14:12] == 3'b000 || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
+              if ((PULP_ZFINX == 0 && instr_rdata_i[14:12] == 3'b000) || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
                 // FP16ALT uses special encoding here
                 if (instr_rdata_i[14]) begin
                   fpu_dst_fmt_o = cv32e40p_fpu_pkg::FP16ALT;
@@ -1371,7 +1371,7 @@ module cv32e40p_decoder
           // Set FPnew OP and OPMOD as the APU op
           apu_op_o = {fpu_vec_op, fpu_op_mod, fpu_op};
 
-        // No FPU or MSTATUS.FS == FS_OFF
+        // No FPU or (PULP_ZFINX == 0 && MSTATUS.FS == FS_OFF)
         end else begin
           illegal_insn_o = 1'b1;
         end
@@ -1382,7 +1382,7 @@ module cv32e40p_decoder
       OPCODE_OP_FMSUB,
       OPCODE_OP_FNMSUB,
       OPCODE_OP_FNMADD : begin
-        if (FPU == 1 && fs_off_i == 1'b0) begin
+        if (FPU == 1 && (PULP_ZFINX == 1 || fs_off_i == 1'b0)) begin
           // using APU instead of ALU
           alu_en        = 1'b0;
           apu_en        = 1'b1;
@@ -1494,24 +1494,20 @@ module cv32e40p_decoder
 
           // Set FPnew OP and OPMOD as the APU op
           apu_op_o = {fpu_vec_op, fpu_op_mod, fpu_op};
-        // No FPU or MSTATUS.FS == FS_OFF
+        // No FPU or (PULP_ZFINX == 0 && MSTATUS.FS == FS_OFF)
         end else begin
           illegal_insn_o = 1'b1;
         end
       end
 
       OPCODE_STORE_FP: begin
-        if (FPU == 1 && fs_off_i == 1'b0) begin
+        if (FPU == 1 && PULP_ZFINX == 0 && fs_off_i == 1'b0) begin
           data_req            = 1'b1;
           data_we_o           = 1'b1;
           rega_used_o         = 1'b1;
           regb_used_o         = 1'b1;
           alu_operator_o      = ALU_ADD;
-          if (PULP_ZFINX == 0) begin
-            reg_fp_b_o        = 1'b1;
-          end else begin
-            reg_fp_b_o        = 1'b0;
-          end
+          reg_fp_b_o          = 1'b1;
 
           // offset from immediate
           imm_b_mux_sel_o     = IMMB_S;
@@ -1542,21 +1538,17 @@ module cv32e40p_decoder
             data_req       = 1'b0;
             data_we_o      = 1'b0;
           end
-        // No FPU or MSTATUS.FS == FS_OFF
+        // No FPU or PULP_ZFINX or MSTATUS.FS == FS_OFF
         end else begin
           illegal_insn_o = 1'b1;
         end
       end
 
       OPCODE_LOAD_FP: begin
-        if (FPU == 1 && fs_off_i == 1'b0) begin
+        if (FPU == 1 && PULP_ZFINX == 0 && fs_off_i == 1'b0) begin
           data_req            = 1'b1;
           regfile_mem_we      = 1'b1;
-          if (PULP_ZFINX == 0) begin
-            reg_fp_d_o        = 1'b1;
-          end else begin
-            reg_fp_d_o        = 1'b0;
-          end
+          reg_fp_d_o          = 1'b1;
           rega_used_o         = 1'b1;
           alu_operator_o      = ALU_ADD;
 
@@ -1583,7 +1575,7 @@ module cv32e40p_decoder
                      else illegal_insn_o = 1'b1;
             default: illegal_insn_o = 1'b1;
           endcase
-        // No FPU or MSTATUS.FS == FS_OFF
+        // No FPU or PULP_ZFINX or MSTATUS.FS == FS_OFF
         end else begin
           illegal_insn_o = 1'b1;
         end
@@ -2773,9 +2765,9 @@ module cv32e40p_decoder
           //   if set or clear with rs == x0 or imm == 0,
           //   then do not perform a write action
           unique case (instr_rdata_i[13:12])
-            2'b01:   csr_op   = CSR_OP_WRITE;
-            2'b10:   csr_op   = instr_rdata_i[19:15] == 5'b0 ? CSR_OP_READ : CSR_OP_SET;
-            2'b11:   csr_op   = instr_rdata_i[19:15] == 5'b0 ? CSR_OP_READ : CSR_OP_CLEAR;
+            2'b01:   csr_op = CSR_OP_WRITE;
+            2'b10:   csr_op = instr_rdata_i[19:15] == 5'b0 ? CSR_OP_READ : CSR_OP_SET;
+            2'b11:   csr_op = instr_rdata_i[19:15] == 5'b0 ? CSR_OP_READ : CSR_OP_CLEAR;
             default: csr_illegal = 1'b1;
           endcase
 
@@ -2790,7 +2782,7 @@ module cv32e40p_decoder
             CSR_FFLAGS,
               CSR_FRM,
               CSR_FCSR :
-                if (FPU == 0 || fs_off_i == 1'b1) csr_illegal = 1'b1;
+                if (FPU == 0 || (PULP_ZFINX == 0 && fs_off_i == 1'b1)) csr_illegal = 1'b1;
 
             //  Writes to read only CSRs results in illegal instruction
             CSR_MVENDORID,

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -2779,10 +2779,17 @@ module cv32e40p_decoder
           // Determine if CSR access is illegal
           case (instr_rdata_i[31:20])
             // Floating point
-            CSR_FFLAGS,
-              CSR_FRM,
+            CSR_FFLAGS :
+                if (FPU == 0) csr_illegal = 1'b1;
+
+            CSR_FRM,
               CSR_FCSR :
-                if (FPU == 0 || (ZFINX == 0 && fs_off_i == 1'b1)) csr_illegal = 1'b1;
+                if (FPU == 0) begin
+                  csr_illegal = 1'b1;
+                end else begin
+                  // FRM updated value needed by following FPU instruction
+                  if (csr_op != CSR_OP_READ) csr_status_o = 1'b1;
+                end
 
             //  Writes to read only CSRs results in illegal instruction
             CSR_MVENDORID,

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -43,7 +43,7 @@ module cv32e40p_decoder
   parameter DEBUG_TRIGGER_EN  = 1
 )
 (
-  // singals running to/from controller
+  // signals running to/from controller
   input  logic        deassert_we_i,           // deassert we, we are stalled or not active
 
   output logic        illegal_insn_o,          // illegal instruction encountered
@@ -1140,7 +1140,7 @@ module cv32e40p_decoder
               unique case (instr_rdata_i[22:20])
                 // Only process instruction if corresponding extension is active (static)
                 3'b000: begin
-                  if (~C_RVF) illegal_insn_o = 1'b1;
+                  if (!(C_RVF && (C_XF16 || C_XF16ALT || C_XF8))) illegal_insn_o = 1'b1;
                   fpu_src_fmt_o = cv32e40p_fpu_pkg::FP32;
                 end
                 3'b001: begin
@@ -1164,6 +1164,7 @@ module cv32e40p_decoder
             end
             // fmulex.s.fmt - FP Expanding Multiplication to FP32
             5'b01001: begin
+              if (~C_XF16 && ~C_XF16ALT && ~C_XF8) illegal_insn_o = 1;
               fpu_op        = cv32e40p_fpu_pkg::MUL;
               fp_op_group   = ADDMUL;
               // set dst format to FP32
@@ -1171,6 +1172,7 @@ module cv32e40p_decoder
             end
             // fmacex.s.fmt - FP Expanding Multipy-Accumulate to FP32
             5'b01010: begin
+              if (~C_XF16 && ~C_XF16ALT && ~C_XF8) illegal_insn_o = 1;
               regc_used_o = 1'b1;
               regc_mux_o  = REGC_RD; // third operand is rd
               if (PULP_ZFINX == 0) begin

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -1308,9 +1308,7 @@ module cv32e40p_decoder
               if (instr_rdata_i[24:20] != 5'b00000) illegal_insn_o = 1'b1;
             end
             // Rest are illegal instructions
-            default: begin
-              illegal_insn_o = 1'b1;
-            end
+            default: illegal_insn_o = 1'b1;
           endcase
 
           // check enabled formats (static)
@@ -1447,6 +1445,7 @@ module cv32e40p_decoder
               fpu_op_mod  = 1'b1;
               apu_op_o    = 2'b11;
             end
+            default : ;
           endcase
 
           // check enabled formats (static)
@@ -2678,9 +2677,7 @@ module cv32e40p_decoder
             fencei_insn_o = 1'b1;
           end
 
-          default: begin
-            illegal_insn_o =  1'b1;
-          end
+          default: illegal_insn_o =  1'b1;
         endcase
       end
 
@@ -2737,10 +2734,7 @@ module cv32e40p_decoder
                 end
               end
 
-              default:
-              begin
-                illegal_insn_o = 1'b1;
-              end
+              default: illegal_insn_o = 1'b1;
             endcase
           end else illegal_insn_o = 1'b1;
         end
@@ -2969,9 +2963,7 @@ module cv32e40p_decoder
 
         end
       end
-      default: begin
-        illegal_insn_o = 1'b1;
-      end
+      default: illegal_insn_o = 1'b1;
     endcase
 
     // make sure invalid compressed instruction causes an exception

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -30,8 +30,8 @@ module cv32e40p_decoder
   import cv32e40p_apu_core_pkg::*;
   import cv32e40p_fpu_pkg::*;
 #(
-  parameter PULP_XPULP        = 1,              // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding cv.elw)
-  parameter PULP_CLUSTER      = 0,              // PULP ISA Extension cv.elw (need PULP_XPULP = 1)
+  parameter COREV_PULP        = 1,              // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding cv.elw)
+  parameter COREV_CLUSTER     = 0,              // PULP ISA Extension cv.elw (need COREV_PULP = 1)
   parameter A_EXTENSION       = 0,
   parameter FPU               = 0,
   parameter FPU_ADDMUL_LAT    = 0,
@@ -1581,7 +1581,7 @@ module cv32e40p_decoder
       end
 
       OPCODE_CUSTOM_0: begin
-        if (PULP_XPULP && instr_rdata_i[14:13] != 3'b11) begin // cv.l[bhw][u] and cv.elw
+        if (COREV_PULP && instr_rdata_i[14:13] != 3'b11) begin // cv.l[bhw][u] and cv.elw
           data_req           = 1'b1;
           regfile_mem_we     = 1'b1;
           rega_used_o        = 1'b1;
@@ -1609,14 +1609,14 @@ module cv32e40p_decoder
 
           // special cv.elw (event load)
           if (instr_rdata_i[13:12] == 2'b11) begin
-            if (PULP_CLUSTER) begin
+            if (COREV_CLUSTER) begin
               data_load_event_o = 1'b1;
             end else begin
-              // cv.elw only valid for PULP_CLUSTER = 1
+              // cv.elw only valid for COREV_CLUSTER = 1
               illegal_insn_o    = 1'b1;
             end
           end
-        end else if (PULP_XPULP) begin   // cv.beqimm and cv.bneimm 
+        end else if (COREV_PULP) begin   // cv.beqimm and cv.bneimm 
           ctrl_transfer_target_mux_sel_o = JT_COND;
           ctrl_transfer_insn             = BRANCH_COND;
           alu_op_c_mux_sel_o             = OP_C_JT;
@@ -1636,7 +1636,7 @@ module cv32e40p_decoder
       end
 
       OPCODE_CUSTOM_1: begin
-        if (PULP_XPULP) begin
+        if (COREV_PULP) begin
           unique case (instr_rdata_i[14:12])
             3'b000, 3'b001, 3'b010: begin  // Immediate Post-Incremented Store
               data_req                = 1'b1;
@@ -2025,7 +2025,7 @@ module cv32e40p_decoder
       end
 
       OPCODE_CUSTOM_2: begin  // PULP specific ALU instructions with two source operands and one immediate
-        if (PULP_XPULP) begin
+        if (COREV_PULP) begin
           regfile_alu_we = 1'b1;
           rega_used_o    = 1'b1;
           regb_used_o    = 1'b1;
@@ -2134,7 +2134,7 @@ module cv32e40p_decoder
       end
 
       OPCODE_CUSTOM_3: begin
-        if (PULP_XPULP) begin
+        if (COREV_PULP) begin
           regfile_alu_we      = 1'b1;
           rega_used_o         = 1'b1;
           imm_b_mux_sel_o     = IMMB_VS;
@@ -2907,15 +2907,15 @@ module cv32e40p_decoder
               CSR_LPSTART1,
               CSR_LPEND1,
               CSR_LPCOUNT1:
-                if (!PULP_XPULP || csr_op != CSR_OP_READ) csr_illegal = 1'b1;
+                if (!COREV_PULP || csr_op != CSR_OP_READ) csr_illegal = 1'b1;
 
             // UHARTID access
             CSR_UHARTID :
-                if (!PULP_XPULP || csr_op != CSR_OP_READ) csr_illegal = 1'b1;
+                if (!COREV_PULP || csr_op != CSR_OP_READ) csr_illegal = 1'b1;
 
             // PRIVLV access
             CSR_PRIVLV :
-                if (!PULP_XPULP || csr_op != CSR_OP_READ) begin
+                if (!COREV_PULP || csr_op != CSR_OP_READ) begin
                   csr_illegal = 1'b1;
                 end else begin
                   csr_status_o = 1'b1;

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -2878,11 +2878,11 @@ module cv32e40p_decoder
 
             // This register only exists in user mode
             CSR_MCOUNTEREN :
-              if (!PULP_SECURE) begin
-                csr_illegal = 1'b1;
-              end else begin
-                csr_status_o = 1'b1;
-              end
+                if (!PULP_SECURE) begin
+                  csr_illegal = 1'b1;
+                end else begin
+                  csr_status_o = 1'b1;
+                end
 
             // Debug register access
             CSR_DCSR,
@@ -2891,9 +2891,9 @@ module cv32e40p_decoder
               CSR_DSCRATCH1 :
                 if (!debug_mode_i) begin
                   csr_illegal = 1'b1;
-              end else begin
-                csr_status_o = 1'b1;
-              end
+                end else begin
+                  csr_status_o = 1'b1;
+                end
 
             // Debug Trigger register access
             CSR_TSELECT,
@@ -2917,15 +2917,15 @@ module cv32e40p_decoder
 
             // UHARTID access
             CSR_UHARTID :
-                if(!PULP_XPULP) csr_illegal = 1'b1;
+                if (!PULP_XPULP || csr_op != CSR_OP_READ) csr_illegal = 1'b1;
 
             // PRIVLV access
             CSR_PRIVLV :
-              if (!PULP_XPULP) begin
-                csr_illegal = 1'b1;
-              end else begin
-                csr_status_o = 1'b1;
-              end
+                if (!PULP_XPULP || csr_op != CSR_OP_READ) begin
+                  csr_illegal = 1'b1;
+                end else begin
+                  csr_status_o = 1'b1;
+                end
 
             // PMP register access
             CSR_PMPCFG0,

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -36,7 +36,7 @@ module cv32e40p_decoder
   parameter FPU               = 0,
   parameter FPU_ADDMUL_LAT    = 0,
   parameter FPU_OTHERS_LAT    = 0,
-  parameter PULP_ZFINX        = 0,
+  parameter ZFINX             = 0,
   parameter PULP_SECURE       = 0,
   parameter USE_PMP           = 0,
   parameter APU_WOP_CPU       = 6,
@@ -535,7 +535,7 @@ module cv32e40p_decoder
               // by default, set all registers to FP registers and use 2
               rega_used_o      = 1'b1;
               regb_used_o      = 1'b1;
-              if (PULP_ZFINX == 0) begin
+              if (ZFINX == 0) begin
                 reg_fp_a_o     = 1'b1;
                 reg_fp_b_o     = 1'b1;
                 reg_fp_d_o     = 1'b1;
@@ -639,7 +639,7 @@ module cv32e40p_decoder
                 5'b01000: begin
                   regc_used_o = 1'b1;
                   regc_mux_o  = REGC_RD; // third operand is rd
-                  if (PULP_ZFINX == 0) begin
+                  if (ZFINX == 0) begin
                     reg_fp_c_o = 1'b1;
                   end else begin
                     reg_fp_c_o = 1'b0;
@@ -651,7 +651,7 @@ module cv32e40p_decoder
                 5'b01001: begin
                   regc_used_o = 1'b1;
                   regc_mux_o  = REGC_RD; // third operand is rd
-                  if (PULP_ZFINX == 0) begin
+                  if (ZFINX == 0) begin
                     reg_fp_c_o = 1'b1;
                   end else begin
                     reg_fp_c_o = 1'b0;
@@ -1010,7 +1010,7 @@ module cv32e40p_decoder
 
       // Floating Point arithmetic
       OPCODE_OP_FP: begin
-        if (FPU == 1 && (PULP_ZFINX == 1 || fs_off_i == 1'b0)) begin
+        if (FPU == 1 && (ZFINX == 1 || fs_off_i == 1'b0)) begin
 
           // using APU instead of ALU
           alu_en           = 1'b0;
@@ -1018,7 +1018,7 @@ module cv32e40p_decoder
           // by default, set all registers to FP registers and use 2
           rega_used_o      = 1'b1;
           regb_used_o      = 1'b1;
-          if (PULP_ZFINX == 0) begin
+          if (ZFINX == 0) begin
             reg_fp_a_o     = 1'b1;
             reg_fp_b_o     = 1'b1;
             reg_fp_d_o     = 1'b1;
@@ -1175,7 +1175,7 @@ module cv32e40p_decoder
               if (~C_XF16 && ~C_XF16ALT && ~C_XF8) illegal_insn_o = 1;
               regc_used_o = 1'b1;
               regc_mux_o  = REGC_RD; // third operand is rd
-              if (PULP_ZFINX == 0) begin
+              if (ZFINX == 0) begin
                 reg_fp_c_o = 1'b1;
               end else begin
                 reg_fp_c_o = 1'b0;
@@ -1260,7 +1260,7 @@ module cv32e40p_decoder
               fp_op_group = NONCOMP;
               check_fprm  = 1'b0; // instruction encoded in rm, do the check here
               // fmv.x.fmt - FPR to GPR Move
-              if ((PULP_ZFINX == 0 && instr_rdata_i[14:12] == 3'b000) || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
+              if ((ZFINX == 0 && instr_rdata_i[14:12] == 3'b000) || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
                 alu_op_b_mux_sel_o  = OP_B_REGA_OR_FWD; // set rs2 = rs1 so we can map FMV to SGNJ in the unit
                 fpu_op              = cv32e40p_fpu_pkg::SGNJ; // mapped to SGNJ-passthrough since no recoding
                 fpu_op_mod          = 1'b1;    // sign-extend result
@@ -1295,7 +1295,7 @@ module cv32e40p_decoder
               fp_op_group         = NONCOMP;
               fp_rnd_mode_o       = 3'b011;  // passthrough without checking nan-box
               check_fprm          = 1'b0; // instruction encoded in rm, do the check here
-              if ((PULP_ZFINX == 0 && instr_rdata_i[14:12] == 3'b000) || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
+              if ((ZFINX == 0 && instr_rdata_i[14:12] == 3'b000) || (C_XF16ALT && instr_rdata_i[14:12] == 3'b100)) begin
                 // FP16ALT uses special encoding here
                 if (instr_rdata_i[14]) begin
                   fpu_dst_fmt_o = cv32e40p_fpu_pkg::FP16ALT;
@@ -1371,7 +1371,7 @@ module cv32e40p_decoder
           // Set FPnew OP and OPMOD as the APU op
           apu_op_o = {fpu_vec_op, fpu_op_mod, fpu_op};
 
-        // No FPU or (PULP_ZFINX == 0 && MSTATUS.FS == FS_OFF)
+        // No FPU or (ZFINX == 0 && MSTATUS.FS == FS_OFF)
         end else begin
           illegal_insn_o = 1'b1;
         end
@@ -1382,7 +1382,7 @@ module cv32e40p_decoder
       OPCODE_OP_FMSUB,
       OPCODE_OP_FNMSUB,
       OPCODE_OP_FNMADD : begin
-        if (FPU == 1 && (PULP_ZFINX == 1 || fs_off_i == 1'b0)) begin
+        if (FPU == 1 && (ZFINX == 1 || fs_off_i == 1'b0)) begin
           // using APU instead of ALU
           alu_en        = 1'b0;
           apu_en        = 1'b1;
@@ -1391,7 +1391,7 @@ module cv32e40p_decoder
           regb_used_o   = 1'b1;
           regc_used_o   = 1'b1;
           regc_mux_o    = REGC_S4;
-          if (PULP_ZFINX == 0) begin
+          if (ZFINX == 0) begin
             reg_fp_a_o  = 1'b1;
             reg_fp_b_o  = 1'b1;
             reg_fp_c_o  = 1'b1;
@@ -1494,14 +1494,14 @@ module cv32e40p_decoder
 
           // Set FPnew OP and OPMOD as the APU op
           apu_op_o = {fpu_vec_op, fpu_op_mod, fpu_op};
-        // No FPU or (PULP_ZFINX == 0 && MSTATUS.FS == FS_OFF)
+        // No FPU or (ZFINX == 0 && MSTATUS.FS == FS_OFF)
         end else begin
           illegal_insn_o = 1'b1;
         end
       end
 
       OPCODE_STORE_FP: begin
-        if (FPU == 1 && PULP_ZFINX == 0 && fs_off_i == 1'b0) begin
+        if (FPU == 1 && ZFINX == 0 && fs_off_i == 1'b0) begin
           data_req            = 1'b1;
           data_we_o           = 1'b1;
           rega_used_o         = 1'b1;
@@ -1538,14 +1538,14 @@ module cv32e40p_decoder
             data_req       = 1'b0;
             data_we_o      = 1'b0;
           end
-        // No FPU or PULP_ZFINX or MSTATUS.FS == FS_OFF
+        // No FPU or ZFINX or MSTATUS.FS == FS_OFF
         end else begin
           illegal_insn_o = 1'b1;
         end
       end
 
       OPCODE_LOAD_FP: begin
-        if (FPU == 1 && PULP_ZFINX == 0 && fs_off_i == 1'b0) begin
+        if (FPU == 1 && ZFINX == 0 && fs_off_i == 1'b0) begin
           data_req            = 1'b1;
           regfile_mem_we      = 1'b1;
           reg_fp_d_o          = 1'b1;
@@ -1575,7 +1575,7 @@ module cv32e40p_decoder
                      else illegal_insn_o = 1'b1;
             default: illegal_insn_o = 1'b1;
           endcase
-        // No FPU or PULP_ZFINX or MSTATUS.FS == FS_OFF
+        // No FPU or ZFINX or MSTATUS.FS == FS_OFF
         end else begin
           illegal_insn_o = 1'b1;
         end
@@ -2782,7 +2782,7 @@ module cv32e40p_decoder
             CSR_FFLAGS,
               CSR_FRM,
               CSR_FCSR :
-                if (FPU == 0 || (PULP_ZFINX == 0 && fs_off_i == 1'b1)) csr_illegal = 1'b1;
+                if (FPU == 0 || (ZFINX == 0 && fs_off_i == 1'b1)) csr_illegal = 1'b1;
 
             //  Writes to read only CSRs results in illegal instruction
             CSR_MVENDORID,

--- a/rtl/cv32e40p_ff_one.sv
+++ b/rtl/cv32e40p_ff_one.sv
@@ -53,6 +53,9 @@ module cv32e40p_ff_one #(
     genvar k;
     genvar l;
     genvar level;
+
+    assign sel_nodes[2**NUM_LEVELS-1] = 1'b0;
+
     for (level = 0; level < NUM_LEVELS; level++) begin : gen_tree
       //------------------------------------------------------------
       if (level < NUM_LEVELS - 1) begin : gen_non_root_level

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -42,7 +42,7 @@ module cv32e40p_id_stage
     parameter FPU = 0,
     parameter FPU_ADDMUL_LAT = 0,
     parameter FPU_OTHERS_LAT = 0,
-    parameter PULP_ZFINX = 0,
+    parameter ZFINX = 0,
     parameter APU_NARGS_CPU = 3,
     parameter APU_WOP_CPU = 6,
     parameter APU_NDSFLAGS_CPU = 15,
@@ -903,7 +903,7 @@ module cv32e40p_id_stage
       .ADDR_WIDTH(6),
       .DATA_WIDTH(32),
       .FPU       (FPU),
-      .PULP_ZFINX(PULP_ZFINX)
+      .ZFINX     (ZFINX)
   ) register_file_i (
       .clk  (clk),
       .rst_n(rst_n),
@@ -950,7 +950,7 @@ module cv32e40p_id_stage
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),
-      .PULP_ZFINX      (PULP_ZFINX),
+      .ZFINX           (ZFINX),
       .PULP_SECURE     (PULP_SECURE),
       .USE_PMP         (USE_PMP),
       .APU_WOP_CPU     (APU_WOP_CPU),

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -31,8 +31,8 @@ module cv32e40p_id_stage
   import cv32e40p_pkg::*;
   import cv32e40p_apu_core_pkg::*;
 #(
-    parameter PULP_XPULP        =  1,                     // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding p.elw)
-    parameter PULP_CLUSTER = 0,
+    parameter COREV_PULP =  1,  // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding cv.elw)
+    parameter COREV_CLUSTER = 0,
     parameter N_HWLP = 2,
     parameter N_HWLP_BITS = $clog2(N_HWLP),
     parameter PULP_SECURE = 0,
@@ -770,7 +770,7 @@ module cv32e40p_id_stage
   end
 
   generate
-    if (!PULP_XPULP) begin
+    if (!COREV_PULP) begin
       assign imm_vec_ext_id = imm_vu_type[1:0];
     end else begin
       assign imm_vec_ext_id = (alu_vec) ? imm_vu_type[1:0] : 2'b0;
@@ -944,8 +944,8 @@ module cv32e40p_id_stage
   ///////////////////////////////////////////////
 
   cv32e40p_decoder #(
-      .PULP_XPULP      (PULP_XPULP),
-      .PULP_CLUSTER    (PULP_CLUSTER),
+      .COREV_PULP      (COREV_PULP),
+      .COREV_CLUSTER   (COREV_CLUSTER),
       .A_EXTENSION     (A_EXTENSION),
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
@@ -1083,8 +1083,8 @@ module cv32e40p_id_stage
   ////////////////////////////////////////////////////////////////////
 
   cv32e40p_controller #(
-      .PULP_CLUSTER(PULP_CLUSTER),
-      .PULP_XPULP  (PULP_XPULP)
+      .COREV_CLUSTER(COREV_CLUSTER),
+      .COREV_PULP   (COREV_PULP)
   ) controller_i (
       .clk          (clk),  // Gated clock
       .clk_ungated_i(clk_ungated_i),  // Ungated clock
@@ -1288,7 +1288,7 @@ module cv32e40p_id_stage
   );
 
   generate
-    if (PULP_XPULP) begin : gen_hwloop_regs
+    if (COREV_PULP) begin : gen_hwloop_regs
 
       ///////////////////////////////////////////////
       //  _   ___        ___     ___   ___  ____   //
@@ -1727,7 +1727,7 @@ module cv32e40p_id_stage
   endgenerate
 
   generate
-    if (!PULP_XPULP) begin : gen_no_pulp_xpulp_assertions
+    if (!COREV_PULP) begin : gen_no_pulp_xpulp_assertions
 
       // Check that PULP extension opcodes are decoded as illegal when PULP extension is not enabled
       property p_illegal_1;

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -143,15 +143,17 @@ module cv32e40p_id_stage
     output logic [APU_NDSFLAGS_CPU-1:0]       apu_flags_ex_o,
     output logic [                 5:0]       apu_waddr_ex_o,
 
-    output logic [     2:0][5:0] apu_read_regs_o,
-    output logic [     2:0]      apu_read_regs_valid_o,
-    input  logic                 apu_read_dep_i,
-    output logic [     1:0][5:0] apu_write_regs_o,
-    output logic [     1:0]      apu_write_regs_valid_o,
-    input  logic                 apu_write_dep_i,
-    output logic                 apu_perf_dep_o,
-    input  logic                 apu_busy_i,
-    input  logic [C_RM-1:0]      frm_i,
+    output logic [2:0][5:0] apu_read_regs_o,
+    output logic [2:0]      apu_read_regs_valid_o,
+    input  logic            apu_read_dep_i,
+    output logic [1:0][5:0] apu_write_regs_o,
+    output logic [1:0]      apu_write_regs_valid_o,
+    input  logic            apu_write_dep_i,
+    output logic            apu_perf_dep_o,
+    input  logic            apu_busy_i,
+
+    input logic            fs_off_i,
+    input logic [C_RM-1:0] frm_i,
 
     // CSR ID/EX
     output logic              csr_access_ex_o,
@@ -1017,6 +1019,7 @@ module cv32e40p_id_stage
       .mult_dot_signed_o (mult_dot_signed),
 
       // FPU / APU signals
+      .fs_off_i     (fs_off_i),
       .frm_i        (frm_i),
       .fpu_src_fmt_o(fpu_src_fmt),
       .fpu_dst_fmt_o(fpu_dst_fmt),

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -26,10 +26,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_if_stage #(
-    parameter PULP_XPULP      = 0,                        // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding p.elw)
+    parameter PULP_XPULP = 0, // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding p.elw)
     parameter PULP_OBI = 0,  // Legacy PULP OBI behavior
     parameter PULP_SECURE = 0,
-    parameter FPU = 0
+    parameter FPU = 0,
+    parameter PULP_ZFINX = 0
 ) (
     input logic clk,
     input logic rst_n,
@@ -54,12 +55,12 @@ module cv32e40p_if_stage #(
     input logic instr_gnt_i,
     input logic instr_rvalid_i,
     input logic [31:0] instr_rdata_i,
-    input  logic                   instr_err_i,      // External bus error (validity defined by instr_rvalid_i) (not used yet)
+    input logic instr_err_i,      // External bus error (validity defined by instr_rvalid_i) (not used yet)
     input logic instr_err_pmp_i,  // PMP error (validity defined by instr_gnt_i)
 
     // Output of IF Pipeline stage
     output logic instr_valid_id_o,  // instruction in IF/ID pipeline is valid
-    output logic       [31:0] instr_rdata_id_o,      // read instruction is sampled and sent to ID stage for decoding
+    output logic [31:0] instr_rdata_id_o,      // read instruction is sampled and sent to ID stage for decoding
     output logic is_compressed_id_o,  // compressed decoder thinks this is a compressed instruction
     output logic illegal_c_insn_id_o,  // compressed decoder thinks this is an invalid instruction
     output logic [31:0] pc_if_o,
@@ -270,7 +271,8 @@ module cv32e40p_if_stage #(
   );
 
   cv32e40p_compressed_decoder #(
-      .FPU(FPU)
+      .FPU       (FPU),
+      .PULP_ZFINX(PULP_ZFINX)
   ) compressed_decoder_i (
       .instr_i        (instr_aligned),
       .instr_o        (instr_decompressed),

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -26,7 +26,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_if_stage #(
-    parameter PULP_XPULP = 0, // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding p.elw)
+    parameter COREV_PULP = 0, // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding cv.elw)
     parameter PULP_OBI = 0,  // Legacy PULP OBI behavior
     parameter PULP_SECURE = 0,
     parameter FPU = 0,
@@ -178,7 +178,7 @@ module cv32e40p_if_stage #(
   // prefetch buffer, caches a fixed number of instructions
   cv32e40p_prefetch_buffer #(
       .PULP_OBI  (PULP_OBI),
-      .PULP_XPULP(PULP_XPULP)
+      .COREV_PULP(COREV_PULP)
   ) prefetch_buffer_i (
       .clk  (clk),
       .rst_n(rst_n),
@@ -287,7 +287,7 @@ module cv32e40p_if_stage #(
 `ifdef CV32E40P_ASSERT_ON
 
   generate
-    if (!PULP_XPULP) begin : gen_no_pulp_xpulp_assertions
+    if (!COREV_PULP) begin : gen_no_pulp_xpulp_assertions
 
       // Check that PC Mux cannot select Hardware Loop address iF PULP extensions are not included
       property p_pc_mux_0;

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -30,7 +30,7 @@ module cv32e40p_if_stage #(
     parameter PULP_OBI = 0,  // Legacy PULP OBI behavior
     parameter PULP_SECURE = 0,
     parameter FPU = 0,
-    parameter PULP_ZFINX = 0
+    parameter ZFINX = 0
 ) (
     input logic clk,
     input logic rst_n,
@@ -271,8 +271,8 @@ module cv32e40p_if_stage #(
   );
 
   cv32e40p_compressed_decoder #(
-      .FPU       (FPU),
-      .PULP_ZFINX(PULP_ZFINX)
+      .FPU  (FPU),
+      .ZFINX(ZFINX)
   ) compressed_decoder_i (
       .instr_i        (instr_aligned),
       .instr_o        (instr_decompressed),

--- a/rtl/cv32e40p_prefetch_buffer.sv
+++ b/rtl/cv32e40p_prefetch_buffer.sv
@@ -26,7 +26,7 @@
 
 module cv32e40p_prefetch_buffer #(
     parameter PULP_OBI = 0,  // Legacy PULP OBI behavior
-    parameter PULP_XPULP = 1                 // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding p.elw)
+    parameter COREV_PULP = 1  // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding p.elw)
 ) (
     input logic clk,
     input logic rst_n,
@@ -86,7 +86,7 @@ module cv32e40p_prefetch_buffer #(
   cv32e40p_prefetch_controller #(
       .DEPTH     (FIFO_DEPTH),
       .PULP_OBI  (PULP_OBI),
-      .PULP_XPULP(PULP_XPULP)
+      .COREV_PULP(COREV_PULP)
   ) prefetch_controller_i (
       .clk  (clk),
       .rst_n(rst_n),

--- a/rtl/cv32e40p_prefetch_controller.sv
+++ b/rtl/cv32e40p_prefetch_controller.sv
@@ -39,7 +39,7 @@
 
 module cv32e40p_prefetch_controller #(
     parameter PULP_OBI = 0,  // Legacy PULP OBI behavior
-    parameter PULP_XPULP      = 1,                                // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding p.elw)
+    parameter COREV_PULP = 1,  // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding cv.elw)
     parameter DEPTH = 4,  // Prefetch FIFO Depth
     parameter FIFO_ADDR_DEPTH = (DEPTH > 1) ? $clog2(DEPTH) : 1  // Do not override this parameter
 ) (
@@ -243,7 +243,7 @@ module cv32e40p_prefetch_controller #(
   end
 
   generate
-    if (PULP_XPULP) begin : gen_hwlp
+    if (COREV_PULP) begin : gen_hwlp
 
       // Flush the FIFO if it is not empty and we are hwlp branching.
       // If HWLP_END is not going to ID, save it from the flush.

--- a/rtl/cv32e40p_register_file_ff.sv
+++ b/rtl/cv32e40p_register_file_ff.sv
@@ -22,7 +22,7 @@
 // Description:    Register file with 31x 32 bit wide registers. Register 0   //
 //                 is fixed to 0. This register file is based on flip-flops.  //
 //                 Also supports the fp-register file now if FPU=1            //
-//                 If PULP_ZFINX is 1, floating point operations take values  //
+//                 If ZFINX is 1, floating point operations take values       //
 //                 from the X register file                                   //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
@@ -31,7 +31,7 @@ module cv32e40p_register_file #(
     parameter ADDR_WIDTH = 5,
     parameter DATA_WIDTH = 32,
     parameter FPU        = 0,
-    parameter PULP_ZFINX = 0
+    parameter ZFINX      = 0
 ) (
     // Clock and Reset
     input logic clk,
@@ -66,7 +66,7 @@ module cv32e40p_register_file #(
   localparam NUM_WORDS = 2 ** (ADDR_WIDTH - 1);
   // number of floating point registers
   localparam NUM_FP_WORDS = 2 ** (ADDR_WIDTH - 1);
-  localparam NUM_TOT_WORDS = FPU ? (PULP_ZFINX ? NUM_WORDS : NUM_WORDS + NUM_FP_WORDS) : NUM_WORDS;
+  localparam NUM_TOT_WORDS = FPU ? (ZFINX ? NUM_WORDS : NUM_WORDS + NUM_FP_WORDS) : NUM_WORDS;
 
   // integer register file
   logic [    NUM_WORDS-1:0][DATA_WIDTH-1:0] mem;
@@ -137,7 +137,7 @@ module cv32e40p_register_file #(
 
     end
 
-    if (FPU == 1 && PULP_ZFINX == 0) begin : gen_mem_fp_write
+    if (FPU == 1 && ZFINX == 0) begin : gen_mem_fp_write
       // Floating point registers
       for (l = 0; l < NUM_FP_WORDS; l++) begin
         always_ff @(posedge clk, negedge rst_n) begin : fp_regs

--- a/rtl/cv32e40p_register_file_latch.sv
+++ b/rtl/cv32e40p_register_file_latch.sv
@@ -24,7 +24,7 @@
 //                 is fixed to 0. This register file is based on latches and  //
 //                 is thus smaller than the flip-flop based register file.    //
 //                 Also supports the fp-register file now if FPU=1            //
-//                 If PULP_ZFINX is 1, floating point operations take values  //
+//                 If ZFINX is 1, floating point operations take values       //
 //                 from the X register file                                   //
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ module cv32e40p_register_file #(
     parameter ADDR_WIDTH = 5,
     parameter DATA_WIDTH = 32,
     parameter FPU        = 0,
-    parameter PULP_ZFINX = 0
+    parameter ZFINX      = 0
 ) (
     // Clock and Reset
     input logic clk,
@@ -68,7 +68,7 @@ module cv32e40p_register_file #(
   localparam NUM_WORDS = 2 ** (ADDR_WIDTH - 1);
   // number of floating point registers
   localparam NUM_FP_WORDS = 2 ** (ADDR_WIDTH - 1);
-  localparam NUM_TOT_WORDS = FPU ? (PULP_ZFINX ? NUM_WORDS : NUM_WORDS + NUM_FP_WORDS) : NUM_WORDS;
+  localparam NUM_TOT_WORDS = FPU ? (ZFINX ? NUM_WORDS : NUM_WORDS + NUM_FP_WORDS) : NUM_WORDS;
 
   // integer register file
   logic [   DATA_WIDTH-1:0] mem            [NUM_WORDS];
@@ -177,7 +177,7 @@ module cv32e40p_register_file #(
     end
   end
 
-  if (FPU == 1 && PULP_ZFINX == 0) begin
+  if (FPU == 1 && ZFINX == 0) begin
     // Floating point registers
     always_latch begin : latch_wdata_fp
       if (FPU == 1) begin

--- a/rtl/cv32e40p_top.sv
+++ b/rtl/cv32e40p_top.sv
@@ -70,6 +70,7 @@ module cv32e40p_top #(
   import cv32e40p_apu_core_pkg::*;
 
   // Core to FPU
+  logic                              clk;
   logic                              apu_req;
   logic [   APU_NARGS_CPU-1:0][31:0] apu_operands;
   logic [     APU_WOP_CPU-1:0]       apu_op;
@@ -143,12 +144,19 @@ module cv32e40p_top #(
   generate
     if (FPU) begin : fpu_gen
       // FPU clock gate
+      cv32e40p_clock_gate core_clock_gate_i (
+          .clk_i       (clk_i),
+          .en_i        (!core_sleep_o),
+          .scan_cg_en_i(scan_cg_en_i),
+          .clk_o       (clk)
+      );
+
       // Instantiate the FPU wrapper
       cv32e40p_fp_wrapper #(
           .FPU_ADDMUL_LAT(FPU_ADDMUL_LAT),
           .FPU_OTHERS_LAT(FPU_OTHERS_LAT)
       ) fp_wrapper_i (
-          .clk_i         (clk_i),
+          .clk_i         (clk),
           .rst_ni        (rst_ni),
           .apu_req_i     (apu_req),
           .apu_gnt_o     (apu_gnt),

--- a/rtl/cv32e40p_top.sv
+++ b/rtl/cv32e40p_top.sv
@@ -8,10 +8,10 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-// Wrapper for a cv32e40p core and optional FPU
+// Top file instantiating a CV32E40P core and an optional FPU
 // Contributor: Davide Schiavone <davide@openhwgroup.org>
 
-module cv32e40p_wrapper #(
+module cv32e40p_top #(
     parameter PULP_XPULP       = 0, // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. p.elw)
     parameter PULP_CLUSTER = 0,  // PULP Cluster interface (incl. p.elw)
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
@@ -142,6 +142,7 @@ module cv32e40p_wrapper #(
 
   generate
     if (FPU) begin : fpu_gen
+      // FPU clock gate
       // Instantiate the FPU wrapper
       cv32e40p_fp_wrapper #(
           .FPU_ADDMUL_LAT(FPU_ADDMUL_LAT),

--- a/rtl/cv32e40p_top.sv
+++ b/rtl/cv32e40p_top.sv
@@ -12,8 +12,8 @@
 // Contributor: Davide Schiavone <davide@openhwgroup.org>
 
 module cv32e40p_top #(
-    parameter PULP_XPULP       = 0, // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. p.elw)
-    parameter PULP_CLUSTER = 0,  // PULP Cluster interface (incl. p.elw)
+    parameter COREV_PULP = 0, // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. cv.elw)
+    parameter COREV_CLUSTER = 0,  // PULP Cluster interface (incl. cv.elw)
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication computing lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion computing lanes pipeline registers number
@@ -24,7 +24,7 @@ module cv32e40p_top #(
     input logic clk_i,
     input logic rst_ni,
 
-    input logic pulp_clock_en_i,  // PULP clock enable (only used if PULP_CLUSTER = 1)
+    input logic pulp_clock_en_i,  // PULP clock enable (only used if COREV_CLUSTER = 1)
     input logic scan_cg_en_i,  // Enable all clock gates for testing
 
     // Core ID, Cluster ID, debug mode halt address and boot address are considered more or less static
@@ -84,8 +84,8 @@ module cv32e40p_top #(
 
   // Instantiate the Core
   cv32e40p_core #(
-      .PULP_XPULP      (PULP_XPULP),
-      .PULP_CLUSTER    (PULP_CLUSTER),
+      .COREV_PULP      (COREV_PULP),
+      .COREV_CLUSTER   (COREV_CLUSTER),
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),

--- a/rtl/cv32e40p_wrapper.sv
+++ b/rtl/cv32e40p_wrapper.sv
@@ -17,7 +17,7 @@ module cv32e40p_wrapper #(
     parameter FPU = 0,  // Floating Point Unit (interfaced via APU interface)
     parameter FPU_ADDMUL_LAT = 0,  // Floating-Point ADDition/MULtiplication computing lane pipeline registers number
     parameter FPU_OTHERS_LAT = 0,  // Floating-Point COMParison/CONVersion computing lanes pipeline registers number
-    parameter PULP_ZFINX = 0,  // Float-in-General Purpose registers
+    parameter ZFINX = 0,  // Float-in-General Purpose registers
     parameter NUM_MHPMCOUNTERS = 1
 ) (
     // Clock and Reset
@@ -88,7 +88,7 @@ module cv32e40p_wrapper #(
       .FPU             (FPU),
       .FPU_ADDMUL_LAT  (FPU_ADDMUL_LAT),
       .FPU_OTHERS_LAT  (FPU_OTHERS_LAT),
-      .PULP_ZFINX      (PULP_ZFINX),
+      .ZFINX           (ZFINX),
       .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
   ) core_i (
       .clk_i (clk_i),

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -539,6 +539,47 @@ package cv32e40p_pkg;
     PRIV_LVL_U = 2'b00
   } PrivLvl_t;
 
+  typedef struct packed {
+    logic uie;
+    // logic sie;      - unimplemented, hardwired to '0
+    // logic hie;      - unimplemented, hardwired to '0
+    logic mie;
+    logic upie;
+    // logic spie;     - unimplemented, hardwired to '0
+    // logic hpie;     - unimplemented, hardwired to '0
+    logic mpie;
+    // logic spp;      - unimplemented, hardwired to '0
+    // logic[1:0] hpp; - unimplemented, hardwired to '0
+    PrivLvl_t mpp;
+    logic mprv;
+  } Status_t;
+
+  typedef struct packed {
+    logic [31:28] xdebugver;
+    logic [27:16] zero2;
+    logic ebreakm;
+    logic zero1;
+    logic ebreaks;
+    logic ebreaku;
+    logic stepie;
+    logic stopcount;
+    logic stoptime;
+    logic [8:6] cause;
+    logic zero0;
+    logic mprven;
+    logic nmip;
+    logic step;
+    PrivLvl_t prv;
+  } Dcsr_t;
+
+  // Floating Point State
+  typedef enum logic [1:0] {
+    FS_OFF     = 2'b00,
+    FS_INITIAL = 2'b01,
+    FS_CLEAN   = 2'b10,
+    FS_DIRTY   = 2'b11
+  } FS_t;
+
   // Machine Vendor ID - OpenHW JEDEC ID is '2 decimal (bank 13)'
   parameter MVENDORID_OFFSET = 7'h2;  // Final byte without parity bit
   parameter MVENDORID_BANK = 25'hC;  // Number of continuation codes

--- a/scripts/lec/lec.sh
+++ b/scripts/lec/lec.sh
@@ -28,7 +28,7 @@ REVISED_RTL=$(pwd)/../../rtl
 
 var_golden_rtl=$(awk '{ if ($0 ~ "sv" && $0 !~ "incdir" && $0 !~ "wrapper" && $0 !~ "tracer") print $0 }' $GOLDEN_RTL/../cv32e40p_manifest.flist | awk -v rtlpath=$GOLDEN_RTL -F "/" '{$1=rtlpath} OFS="/"')
 
-var_revised_rtl=$(awk '{ if ($0 ~ "sv" && $0 !~ "incdir" && $0 !~ "wrapper" && $0 !~ "tracer") print $0 }' $REVISED_RTL/../cv32e40p_manifest.flist | awk -v rtlpath=$REVISED_RTL -F "/" '{$1=rtlpath} OFS="/"')
+var_revised_rtl=$(awk '{ if ($0 ~ "sv" && $0 !~ "incdir" && $0 !~ "wrapper" && $0 !~ "_top" && $0 !~ "tracer") print $0 }' $REVISED_RTL/../cv32e40p_manifest.flist | awk -v rtlpath=$REVISED_RTL -F "/" '{$1=rtlpath} OFS="/"')
 
 echo $var_golden_rtl > golden.src
 echo $var_revised_rtl > revised.src


### PR DESCRIPTION
Issue #170 correction: Adding MSTATUS.FS/SD

Issue #724 correction: Illegal exception for unknown F instructions.

Move from PULP_ZFINX to ratified v1.0 ZFINX.
Issue #725 correction: Illegal exception for FMV/FLW/FSW when ZFINX.
Updated MISA value and make MSTATUS.FS/SD ZFINX dependent.

Move PULP_ZFINX parameter to ZFINX in all RTL files.
Removed PULP_XPULP, PULP_CLUSTER, FPU, PULP_ZFINX assertions.

Issue #174 and #169 correction: Flush instructions following CSRW to FRM/FCSR.

Issue #741 correction: Illegal exception when CSRW to uhartid and privlv.

Renamed cv32e40p_wrapper to cv32e40p_top and updated all files from wrapper to top instantiation.

Added in cv32e40p_top a clock gating cell for FPU.

Updates to allow MSTATUS.FS and SD comparison with Imperas ISS.

Moved PULP_XPULP to COREV_PULP and PULP_CLUSTER to COREV_CLUSTER.