### PR TITLE
HW loop csr + improved FPU instruction 

### DIFF
--- a/bhv/cv32e40p_apu_tracer.sv
+++ b/bhv/cv32e40p_apu_tracer.sv
@@ -52,7 +52,7 @@ module cv32e40p_apu_tracer (
 
   // open/close output file for writing
   initial begin
-    wait(rst_n == 1'b1);
+    wait (rst_n == 1'b1);
     $sformat(fn, "apu_trace_core_%h.log", hart_id_i);
     $display("[APU_TRACER %2d] Output filename is: %s", hart_id_i, fn);
     apu_trace = $fopen(fn, "w");

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -76,21 +76,21 @@ module cv32e40p_rvfi
 
     input logic [5:0] csr_cause_i,
 
-    input logic        debug_csr_save_i,
+    input logic              debug_csr_save_i,
     // HWLOOP regs
     input logic [ 1:0][31:0] hwlp_start_q_i,
     input logic [ 1:0][31:0] hwlp_end_q_i,
     input logic [ 1:0][31:0] hwlp_counter_q_i,
     input logic [ 1:0][31:0] hwlp_counter_n_i,
     // LSU
-    input logic        lsu_en_id_i,
-    input logic        lsu_we_id_i,
-    input logic [ 1:0] lsu_size_id_i,
+    input logic              lsu_en_id_i,
+    input logic              lsu_we_id_i,
+    input logic [ 1:0]       lsu_size_id_i,
     // Register reads
-    input logic [ 5:0] rs1_addr_id_i,
-    input logic [ 5:0] rs2_addr_id_i,
-    input logic [31:0] operand_a_fw_id_i,
-    input logic [31:0] operand_b_fw_id_i,
+    input logic [ 5:0]       rs1_addr_id_i,
+    input logic [ 5:0]       rs2_addr_id_i,
+    input logic [31:0]       operand_a_fw_id_i,
+    input logic [31:0]       operand_b_fw_id_i,
 
     //// EX probes ////
 
@@ -691,16 +691,16 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   logic [31:0] s_fcsr_mirror;
   function void set_rvfi();
     insn_trace_t new_rvfi_trace;
-    new_rvfi_trace   = rvfi_trace_q.pop_front();
+    new_rvfi_trace = rvfi_trace_q.pop_front();
 
-    if(new_rvfi_trace.m_is_apu) begin
-      if(new_rvfi_trace.m_csr.fflags_we) begin
+    if (new_rvfi_trace.m_is_apu) begin
+      if (new_rvfi_trace.m_csr.fflags_we) begin
         s_fflags_mirror = new_rvfi_trace.m_csr.fflags_wdata;
       end
-      if(new_rvfi_trace.m_csr.frm_we) begin
+      if (new_rvfi_trace.m_csr.frm_we) begin
         s_frm_mirror = new_rvfi_trace.m_csr.frm_wdata;
       end
-      if(new_rvfi_trace.m_csr.fcsr_we) begin
+      if (new_rvfi_trace.m_csr.fcsr_we) begin
         s_fcsr_mirror = new_rvfi_trace.m_csr.fcsr_wdata;
       end
 
@@ -928,51 +928,51 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   endfunction
 
   function void lpcount1_to_id();
-    trace_id.m_csr.lpcount1_we      = '0;
-    trace_id.m_csr.lpcount1_rdata   = r_pipe_freeze_trace.hwloop.counter_q[1];
-    trace_id.m_csr.lpcount1_rmask   = '1;
-    trace_id.m_csr.lpcount1_wdata   = '0;
-    trace_id.m_csr.lpcount1_wmask   = '0;
+    trace_id.m_csr.lpcount1_we    = '0;
+    trace_id.m_csr.lpcount1_rdata = r_pipe_freeze_trace.hwloop.counter_q[1];
+    trace_id.m_csr.lpcount1_rmask = '1;
+    trace_id.m_csr.lpcount1_wdata = '0;
+    trace_id.m_csr.lpcount1_wmask = '0;
   endfunction
 
   function void lpcount0_to_id();
-    trace_id.m_csr.lpcount0_we      = '0;
-    trace_id.m_csr.lpcount0_rdata   = r_pipe_freeze_trace.hwloop.counter_q[0];
-    trace_id.m_csr.lpcount0_rmask   = '1;
-    trace_id.m_csr.lpcount0_wdata   = '0;
-    trace_id.m_csr.lpcount0_wmask   = '0;
+    trace_id.m_csr.lpcount0_we    = '0;
+    trace_id.m_csr.lpcount0_rdata = r_pipe_freeze_trace.hwloop.counter_q[0];
+    trace_id.m_csr.lpcount0_rmask = '1;
+    trace_id.m_csr.lpcount0_wdata = '0;
+    trace_id.m_csr.lpcount0_wmask = '0;
   endfunction
 
   function void lpend0_to_id();
-    trace_id.m_csr.lpend0_we      = '0;
-    trace_id.m_csr.lpend0_rdata   = r_pipe_freeze_trace.hwloop.end_q[0];
-    trace_id.m_csr.lpend0_rmask   = '1;
-    trace_id.m_csr.lpend0_wdata   = '0;
-    trace_id.m_csr.lpend0_wmask   = '0;
+    trace_id.m_csr.lpend0_we    = '0;
+    trace_id.m_csr.lpend0_rdata = r_pipe_freeze_trace.hwloop.end_q[0];
+    trace_id.m_csr.lpend0_rmask = '1;
+    trace_id.m_csr.lpend0_wdata = '0;
+    trace_id.m_csr.lpend0_wmask = '0;
   endfunction
 
   function void lpend1_to_id();
-    trace_id.m_csr.lpend1_we      = '0;
-    trace_id.m_csr.lpend1_rdata   = r_pipe_freeze_trace.hwloop.end_q[1];
-    trace_id.m_csr.lpend1_rmask   = '1;
-    trace_id.m_csr.lpend1_wdata   = '0;
-    trace_id.m_csr.lpend1_wmask   = '0;
+    trace_id.m_csr.lpend1_we    = '0;
+    trace_id.m_csr.lpend1_rdata = r_pipe_freeze_trace.hwloop.end_q[1];
+    trace_id.m_csr.lpend1_rmask = '1;
+    trace_id.m_csr.lpend1_wdata = '0;
+    trace_id.m_csr.lpend1_wmask = '0;
   endfunction
 
   function void lpstart0_to_id();
-    trace_id.m_csr.lpstart0_we      = '0;
-    trace_id.m_csr.lpstart0_rdata   = r_pipe_freeze_trace.hwloop.start_q[0];
-    trace_id.m_csr.lpstart0_rmask   = '1;
-    trace_id.m_csr.lpstart0_wdata   = '0;
-    trace_id.m_csr.lpstart0_wmask   = '0;
+    trace_id.m_csr.lpstart0_we    = '0;
+    trace_id.m_csr.lpstart0_rdata = r_pipe_freeze_trace.hwloop.start_q[0];
+    trace_id.m_csr.lpstart0_rmask = '1;
+    trace_id.m_csr.lpstart0_wdata = '0;
+    trace_id.m_csr.lpstart0_wmask = '0;
   endfunction
 
   function void lpstart1_to_id();
-    trace_id.m_csr.lpstart1_we      = '0;
-    trace_id.m_csr.lpstart1_rdata   = r_pipe_freeze_trace.hwloop.start_q[1];
-    trace_id.m_csr.lpstart1_rmask   = '1;
-    trace_id.m_csr.lpstart1_wdata   = '0;
-    trace_id.m_csr.lpstart1_wmask   = '0;
+    trace_id.m_csr.lpstart1_we    = '0;
+    trace_id.m_csr.lpstart1_rdata = r_pipe_freeze_trace.hwloop.start_q[1];
+    trace_id.m_csr.lpstart1_rmask = '1;
+    trace_id.m_csr.lpstart1_wdata = '0;
+    trace_id.m_csr.lpstart1_wmask = '0;
   endfunction
 
   function void hwloop_to_id();

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -77,6 +77,11 @@ module cv32e40p_rvfi
     input logic [5:0] csr_cause_i,
 
     input logic        debug_csr_save_i,
+    // HWLOOP regs
+    input logic [ 1:0][31:0] hwlp_start_q_i,
+    input logic [ 1:0][31:0] hwlp_end_q_i,
+    input logic [ 1:0][31:0] hwlp_counter_q_i,
+    input logic [ 1:0][31:0] hwlp_counter_n_i,
     // LSU
     input logic        lsu_en_id_i,
     input logic        lsu_we_id_i,
@@ -561,7 +566,32 @@ module cv32e40p_rvfi
     output logic [31:0] rvfi_csr_mconfigptr_rmask,
     output logic [31:0] rvfi_csr_mconfigptr_wmask,
     output logic [31:0] rvfi_csr_mconfigptr_rdata,
-    output logic [31:0] rvfi_csr_mconfigptr_wdata
+    output logic [31:0] rvfi_csr_mconfigptr_wdata,
+
+    output logic [31:0] rvfi_csr_lpstart0_rmask,
+    output logic [31:0] rvfi_csr_lpstart0_wmask,
+    output logic [31:0] rvfi_csr_lpstart0_rdata,
+    output logic [31:0] rvfi_csr_lpstart0_wdata,
+    output logic [31:0] rvfi_csr_lpend0_rmask,
+    output logic [31:0] rvfi_csr_lpend0_wmask,
+    output logic [31:0] rvfi_csr_lpend0_rdata,
+    output logic [31:0] rvfi_csr_lpend0_wdata,
+    output logic [31:0] rvfi_csr_lpcount0_rmask,
+    output logic [31:0] rvfi_csr_lpcount0_wmask,
+    output logic [31:0] rvfi_csr_lpcount0_rdata,
+    output logic [31:0] rvfi_csr_lpcount0_wdata,
+    output logic [31:0] rvfi_csr_lpstart1_rmask,
+    output logic [31:0] rvfi_csr_lpstart1_wmask,
+    output logic [31:0] rvfi_csr_lpstart1_rdata,
+    output logic [31:0] rvfi_csr_lpstart1_wdata,
+    output logic [31:0] rvfi_csr_lpend1_rmask,
+    output logic [31:0] rvfi_csr_lpend1_wmask,
+    output logic [31:0] rvfi_csr_lpend1_rdata,
+    output logic [31:0] rvfi_csr_lpend1_wdata,
+    output logic [31:0] rvfi_csr_lpcount1_rmask,
+    output logic [31:0] rvfi_csr_lpcount1_wmask,
+    output logic [31:0] rvfi_csr_lpcount1_rdata,
+    output logic [31:0] rvfi_csr_lpcount1_wdata
 );
 
 
@@ -791,6 +821,13 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     `SET_RVFI_CSR_FROM_INSN(frm)
     `SET_RVFI_CSR_FROM_INSN(fcsr)
 
+    `SET_RVFI_CSR_FROM_INSN(lpstart0)
+    `SET_RVFI_CSR_FROM_INSN(lpend0)
+    `SET_RVFI_CSR_FROM_INSN(lpcount0)
+    `SET_RVFI_CSR_FROM_INSN(lpstart1)
+    `SET_RVFI_CSR_FROM_INSN(lpend1)
+    `SET_RVFI_CSR_FROM_INSN(lpcount1)
+
   endfunction
 
   function void minstret_to_id();
@@ -866,6 +903,66 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     trace_id.m_csr.marchid_rmask   = '0;
     trace_id.m_csr.marchid_wdata   = '0;
     trace_id.m_csr.marchid_wmask   = '0;
+  endfunction
+
+  function void lpcount1_to_id();
+    trace_id.m_csr.lpcount1_we      = '0;
+    trace_id.m_csr.lpcount1_rdata   = r_pipe_freeze_trace.hwloop.counter_q[1];
+    trace_id.m_csr.lpcount1_rmask   = '1;
+    trace_id.m_csr.lpcount1_wdata   = '0;
+    trace_id.m_csr.lpcount1_wmask   = '0;
+  endfunction
+
+  function void lpcount0_to_id();
+    trace_id.m_csr.lpcount0_we      = '0;
+    trace_id.m_csr.lpcount0_rdata   = r_pipe_freeze_trace.hwloop.counter_q[0];
+    trace_id.m_csr.lpcount0_rmask   = '1;
+    trace_id.m_csr.lpcount0_wdata   = '0;
+    trace_id.m_csr.lpcount0_wmask   = '0;
+  endfunction
+
+  function void lpend0_to_id();
+    trace_id.m_csr.lpend0_we      = '0;
+    trace_id.m_csr.lpend0_rdata   = r_pipe_freeze_trace.hwloop.end_q[0];
+    trace_id.m_csr.lpend0_rmask   = '1;
+    trace_id.m_csr.lpend0_wdata   = '0;
+    trace_id.m_csr.lpend0_wmask   = '0;
+  endfunction
+
+  function void lpend1_to_id();
+    trace_id.m_csr.lpend1_we      = '0;
+    trace_id.m_csr.lpend1_rdata   = r_pipe_freeze_trace.hwloop.end_q[1];
+    trace_id.m_csr.lpend1_rmask   = '1;
+    trace_id.m_csr.lpend1_wdata   = '0;
+    trace_id.m_csr.lpend1_wmask   = '0;
+  endfunction
+
+  function void lpstart0_to_id();
+    trace_id.m_csr.lpstart0_we      = '0;
+    trace_id.m_csr.lpstart0_rdata   = r_pipe_freeze_trace.hwloop.start_q[0];
+    trace_id.m_csr.lpstart0_rmask   = '1;
+    trace_id.m_csr.lpstart0_wdata   = '0;
+    trace_id.m_csr.lpstart0_wmask   = '0;
+  endfunction
+
+  function void lpstart1_to_id();
+    trace_id.m_csr.lpstart1_we      = '0;
+    trace_id.m_csr.lpstart1_rdata   = r_pipe_freeze_trace.hwloop.start_q[1];
+    trace_id.m_csr.lpstart1_rmask   = '1;
+    trace_id.m_csr.lpstart1_wdata   = '0;
+    trace_id.m_csr.lpstart1_wmask   = '0;
+  endfunction
+
+  function void hwloop_to_id();
+    lpcount0_to_id();
+    lpend0_to_id();
+    lpstart0_to_id();
+
+    lpcount1_to_id();
+    lpend1_to_id();
+    lpstart1_to_id();
+
+
   endfunction
 
   function void check_trap();
@@ -1250,6 +1347,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
             end
           end
           ->e_id_to_ex_1;
+          hwloop_to_id();
           trace_ex.move_down_pipe(trace_id);  // The instruction moves forward from ID to EX
           trace_id.m_valid = 1'b0;
 
@@ -1297,6 +1395,8 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
             trace_id.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
           end
           ->e_id_to_ex_2;
+
+          hwloop_to_id();
           trace_ex.move_down_pipe(trace_id);
           trace_id.m_valid = 1'b0;
         end

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -291,7 +291,7 @@ module cv32e40p_rvfi
     input logic [ 7:0] csr_pmpcfg_n_i   [16],
     input logic [ 7:0] csr_pmpcfg_q_i   [16],
     input logic [15:0] csr_pmpcfg_we_i,
-    input logic [31:0] csr_pmpaddr_n_i,  // PMP address input shared for all pmpaddr registers
+    input logic [31:0] csr_pmpaddr_n_i,        // PMP address input shared for all pmpaddr registers
     input logic [31:0] csr_pmpaddr_q_i  [16],
     input logic [15:0] csr_pmpaddr_we_i,
     input logic [31:0] csr_mseccfg_n_i,
@@ -396,7 +396,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_mcountinhibit_wmask,
     output logic [31:0]       rvfi_csr_mcountinhibit_rdata,
     output logic [31:0]       rvfi_csr_mcountinhibit_wdata,
-    output logic [31:0][31:0] rvfi_csr_mhpmevent_rmask,  // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_mhpmevent_rmask,      // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_mhpmevent_wmask,
     output logic [31:0][31:0] rvfi_csr_mhpmevent_rdata,
     output logic [31:0][31:0] rvfi_csr_mhpmevent_wdata,
@@ -448,7 +448,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_tselect_wmask,
     output logic [31:0]       rvfi_csr_tselect_rdata,
     output logic [31:0]       rvfi_csr_tselect_wdata,
-    output logic [ 3:0][31:0] rvfi_csr_tdata_rmask,  // 1-3 implemented
+    output logic [ 3:0][31:0] rvfi_csr_tdata_rmask,          // 1-3 implemented
     output logic [ 3:0][31:0] rvfi_csr_tdata_wmask,
     output logic [ 3:0][31:0] rvfi_csr_tdata_rdata,
     output logic [ 3:0][31:0] rvfi_csr_tdata_wdata,
@@ -472,7 +472,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_dpc_wmask,
     output logic [31:0]       rvfi_csr_dpc_rdata,
     output logic [31:0]       rvfi_csr_dpc_wdata,
-    output logic [ 1:0][31:0] rvfi_csr_dscratch_rmask,  // 0-1 implemented
+    output logic [ 1:0][31:0] rvfi_csr_dscratch_rmask,       // 0-1 implemented
     output logic [ 1:0][31:0] rvfi_csr_dscratch_wmask,
     output logic [ 1:0][31:0] rvfi_csr_dscratch_rdata,
     output logic [ 1:0][31:0] rvfi_csr_dscratch_wdata,
@@ -484,7 +484,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_minstret_wmask,
     output logic [31:0]       rvfi_csr_minstret_rdata,
     output logic [31:0]       rvfi_csr_minstret_wdata,
-    output logic [31:0][31:0] rvfi_csr_mhpmcounter_rmask,  // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_mhpmcounter_rmask,    // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_mhpmcounter_wmask,
     output logic [31:0][31:0] rvfi_csr_mhpmcounter_rdata,
     output logic [31:0][31:0] rvfi_csr_mhpmcounter_wdata,
@@ -496,7 +496,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_minstreth_wmask,
     output logic [31:0]       rvfi_csr_minstreth_rdata,
     output logic [31:0]       rvfi_csr_minstreth_wdata,
-    output logic [31:0][31:0] rvfi_csr_mhpmcounterh_rmask,  // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_mhpmcounterh_rmask,   // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_mhpmcounterh_wmask,
     output logic [31:0][31:0] rvfi_csr_mhpmcounterh_rdata,
     output logic [31:0][31:0] rvfi_csr_mhpmcounterh_wdata,
@@ -508,7 +508,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_instret_wmask,
     output logic [31:0]       rvfi_csr_instret_rdata,
     output logic [31:0]       rvfi_csr_instret_wdata,
-    output logic [31:0][31:0] rvfi_csr_hpmcounter_rmask,  // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_hpmcounter_rmask,     // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_hpmcounter_wmask,
     output logic [31:0][31:0] rvfi_csr_hpmcounter_rdata,
     output logic [31:0][31:0] rvfi_csr_hpmcounter_wdata,
@@ -520,7 +520,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_instreth_wmask,
     output logic [31:0]       rvfi_csr_instreth_rdata,
     output logic [31:0]       rvfi_csr_instreth_wdata,
-    output logic [31:0][31:0] rvfi_csr_hpmcounterh_rmask,  // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_hpmcounterh_rmask,    // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_hpmcounterh_wmask,
     output logic [31:0][31:0] rvfi_csr_hpmcounterh_rdata,
     output logic [31:0][31:0] rvfi_csr_hpmcounterh_wdata,
@@ -1146,7 +1146,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
 
     $display("*****Starting pipeline computing*****\n");
     forever begin
-      wait(e_pipe_monitor_ok.triggered);
+      wait (e_pipe_monitor_ok.triggered);
       #1;
 
       check_trap();
@@ -1529,16 +1529,16 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     rvfi_mode        = 2'b11;  //priv_lvl_i; //TODO: correct this if needed
 
     $display("*****Starting update rvfi task*****\n");
-    wait(clk_i_d == 1'b1);
+    wait (clk_i_d == 1'b1);
     forever begin
-      wait(clk_i_d == 1'b1);
+      wait (clk_i_d == 1'b1);
       if (rvfi_trace_q.size() != 0) begin
         set_rvfi();
         rvfi_valid = 1'b1;
       end else begin
         rvfi_valid = 1'b0;
       end
-      wait(clk_i_d == 1'b0);
+      wait (clk_i_d == 1'b0);
     end
   endtask
 

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -291,7 +291,7 @@ module cv32e40p_rvfi
     input logic [ 7:0] csr_pmpcfg_n_i   [16],
     input logic [ 7:0] csr_pmpcfg_q_i   [16],
     input logic [15:0] csr_pmpcfg_we_i,
-    input logic [31:0] csr_pmpaddr_n_i,        // PMP address input shared for all pmpaddr registers
+    input logic [31:0] csr_pmpaddr_n_i,  // PMP address input shared for all pmpaddr registers
     input logic [31:0] csr_pmpaddr_q_i  [16],
     input logic [15:0] csr_pmpaddr_we_i,
     input logic [31:0] csr_mseccfg_n_i,
@@ -396,7 +396,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_mcountinhibit_wmask,
     output logic [31:0]       rvfi_csr_mcountinhibit_rdata,
     output logic [31:0]       rvfi_csr_mcountinhibit_wdata,
-    output logic [31:0][31:0] rvfi_csr_mhpmevent_rmask,      // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_mhpmevent_rmask,  // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_mhpmevent_wmask,
     output logic [31:0][31:0] rvfi_csr_mhpmevent_rdata,
     output logic [31:0][31:0] rvfi_csr_mhpmevent_wdata,
@@ -448,7 +448,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_tselect_wmask,
     output logic [31:0]       rvfi_csr_tselect_rdata,
     output logic [31:0]       rvfi_csr_tselect_wdata,
-    output logic [ 3:0][31:0] rvfi_csr_tdata_rmask,          // 1-3 implemented
+    output logic [ 3:0][31:0] rvfi_csr_tdata_rmask,  // 1-3 implemented
     output logic [ 3:0][31:0] rvfi_csr_tdata_wmask,
     output logic [ 3:0][31:0] rvfi_csr_tdata_rdata,
     output logic [ 3:0][31:0] rvfi_csr_tdata_wdata,
@@ -472,7 +472,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_dpc_wmask,
     output logic [31:0]       rvfi_csr_dpc_rdata,
     output logic [31:0]       rvfi_csr_dpc_wdata,
-    output logic [ 1:0][31:0] rvfi_csr_dscratch_rmask,       // 0-1 implemented
+    output logic [ 1:0][31:0] rvfi_csr_dscratch_rmask,  // 0-1 implemented
     output logic [ 1:0][31:0] rvfi_csr_dscratch_wmask,
     output logic [ 1:0][31:0] rvfi_csr_dscratch_rdata,
     output logic [ 1:0][31:0] rvfi_csr_dscratch_wdata,
@@ -484,7 +484,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_minstret_wmask,
     output logic [31:0]       rvfi_csr_minstret_rdata,
     output logic [31:0]       rvfi_csr_minstret_wdata,
-    output logic [31:0][31:0] rvfi_csr_mhpmcounter_rmask,    // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_mhpmcounter_rmask,  // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_mhpmcounter_wmask,
     output logic [31:0][31:0] rvfi_csr_mhpmcounter_rdata,
     output logic [31:0][31:0] rvfi_csr_mhpmcounter_wdata,
@@ -496,7 +496,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_minstreth_wmask,
     output logic [31:0]       rvfi_csr_minstreth_rdata,
     output logic [31:0]       rvfi_csr_minstreth_wdata,
-    output logic [31:0][31:0] rvfi_csr_mhpmcounterh_rmask,   // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_mhpmcounterh_rmask,  // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_mhpmcounterh_wmask,
     output logic [31:0][31:0] rvfi_csr_mhpmcounterh_rdata,
     output logic [31:0][31:0] rvfi_csr_mhpmcounterh_wdata,
@@ -508,7 +508,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_instret_wmask,
     output logic [31:0]       rvfi_csr_instret_rdata,
     output logic [31:0]       rvfi_csr_instret_wdata,
-    output logic [31:0][31:0] rvfi_csr_hpmcounter_rmask,     // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_hpmcounter_rmask,  // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_hpmcounter_wmask,
     output logic [31:0][31:0] rvfi_csr_hpmcounter_rdata,
     output logic [31:0][31:0] rvfi_csr_hpmcounter_wdata,
@@ -520,7 +520,7 @@ module cv32e40p_rvfi
     output logic [31:0]       rvfi_csr_instreth_wmask,
     output logic [31:0]       rvfi_csr_instreth_rdata,
     output logic [31:0]       rvfi_csr_instreth_wdata,
-    output logic [31:0][31:0] rvfi_csr_hpmcounterh_rmask,    // 3-31 implemented
+    output logic [31:0][31:0] rvfi_csr_hpmcounterh_rmask,  // 3-31 implemented
     output logic [31:0][31:0] rvfi_csr_hpmcounterh_wmask,
     output logic [31:0][31:0] rvfi_csr_hpmcounterh_rdata,
     output logic [31:0][31:0] rvfi_csr_hpmcounterh_wdata,
@@ -720,7 +720,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
         new_rvfi_trace.m_csr.fflags_wmask = 32'hFFFF_FFFF;
         new_rvfi_trace.m_csr.fcsr_wmask = 32'hFFFF_FFFF;
       end
-      if(new_rvfi_trace.m_frm_we_non_apu)begin
+      if (new_rvfi_trace.m_frm_we_non_apu) begin
         s_frm_mirror = new_rvfi_trace.m_csr.frm_wdata;
         s_fcsr_mirror = new_rvfi_trace.m_csr.fcsr_wdata;
         new_rvfi_trace.m_csr.frm_wmask = 32'hFFFF_FFFF;
@@ -1168,7 +1168,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
 
     $display("*****Starting pipeline computing*****\n");
     forever begin
-      wait (e_pipe_monitor_ok.triggered);
+      wait(e_pipe_monitor_ok.triggered);
       #1;
 
       check_trap();
@@ -1238,15 +1238,15 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       s_wb_valid_adjusted = r_pipe_freeze_trace.wb_valid && (r_pipe_freeze_trace.ctrl_fsm_cs == DECODE);// && !r_pipe_freeze_trace.apu_rvalid;;
 
       s_fflags_we_non_apu = 1'b0;
-      if(r_pipe_freeze_trace.csr.fflags_we) begin
-        if(cnt_apu_resp == cnt_apu_req) begin //No ongoing apu instruction
+      if (r_pipe_freeze_trace.csr.fflags_we) begin
+        if (cnt_apu_resp == cnt_apu_req) begin  //No ongoing apu instruction
           s_fflags_we_non_apu = 1'b1;
         end
       end
 
       s_frm_we_non_apu = 1'b0;
-      if(r_pipe_freeze_trace.csr.frm_we) begin
-        if(cnt_apu_resp == cnt_apu_req) begin //No ongoing apu instruction
+      if (r_pipe_freeze_trace.csr.frm_we) begin
+        if (cnt_apu_resp == cnt_apu_req) begin  //No ongoing apu instruction
           s_frm_we_non_apu = 1'b1;
         end
       end
@@ -1572,16 +1572,16 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     rvfi_mode        = 2'b11;  //priv_lvl_i; //TODO: correct this if needed
 
     $display("*****Starting update rvfi task*****\n");
-    wait (clk_i_d == 1'b1);
+    wait(clk_i_d == 1'b1);
     forever begin
-      wait (clk_i_d == 1'b1);
+      wait(clk_i_d == 1'b1);
       if (rvfi_trace_q.size() != 0) begin
         set_rvfi();
         rvfi_valid = 1'b1;
       end else begin
         rvfi_valid = 1'b0;
       end
-      wait (clk_i_d == 1'b0);
+      wait(clk_i_d == 1'b0);
     end
   endtask
 

--- a/bhv/cv32e40p_rvfi_trace.sv
+++ b/bhv/cv32e40p_rvfi_trace.sv
@@ -181,7 +181,7 @@ instr_trace_t trace_retire;
   end
 
   initial begin
-    wait(rst_n == 1'b1);
+    wait (rst_n == 1'b1);
     $sformat(fn, "trace_core.log");
     $sformat(info_tag, "CORE_TRACER %2d", hart_id_i);
     $display("[%s] Output filename is: %s", info_tag, fn);

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -263,12 +263,16 @@ module cv32e40p_tb_wrapper
       .debug_csr_save_i  (cv32e40p_top_i.core_i.debug_csr_save),
 
       //// EX probes ////
-      .ex_valid_i    (cv32e40p_top_i.core_i.ex_valid),
-      .ex_ready_i    (cv32e40p_top_i.core_i.ex_ready),
-      .ex_reg_addr_i (cv32e40p_top_i.core_i.regfile_alu_waddr_fw),
-      .ex_reg_we_i   (cv32e40p_top_i.core_i.regfile_alu_we_fw),
-      .ex_reg_wdata_i(cv32e40p_top_i.core_i.regfile_alu_wdata_fw),
-      .apu_en_ex_i   (cv32e40p_top_i.core_i.apu_en_ex),
+      .ex_valid_i         (cv32e40p_top_i.core_i.ex_valid),
+      .ex_ready_i         (cv32e40p_top_i.core_i.ex_ready),
+      .ex_reg_addr_i      (cv32e40p_top_i.core_i.regfile_alu_waddr_fw),
+      .ex_reg_we_i        (cv32e40p_top_i.core_i.regfile_alu_we_fw),
+      .ex_reg_wdata_i     (cv32e40p_top_i.core_i.regfile_alu_wdata_fw),
+      .apu_en_ex_i        (cv32e40p_top_i.core_i.apu_en_ex),
+      .apu_singlecycle_i  (cv32e40p_top_i.core_i.ex_stage_i.apu_singlecycle),
+      .apu_multicycle_i   (cv32e40p_top_i.core_i.ex_stage_i.apu_multicycle),
+      .wb_contention_lsu_i(cv32e40p_top_i.core_i.ex_stage_i.wb_contention_lsu),
+      .wb_contention_i    (cv32e40p_top_i.core_i.ex_stage_i.wb_contention),
 
       // .rf_we_alu_i    (cv32e40p_top_i.core_i.id_stage_i.regfile_alu_we_fw_i),
       // .rf_addr_alu_i  (cv32e40p_top_i.core_i.id_stage_i.regfile_alu_waddr_fw_i),
@@ -387,10 +391,11 @@ module cv32e40p_tb_wrapper
       }),  //TODO: get this from the design instead of the pkg
       .csr_marchid_i(MARCHID),  //TODO: get this from the design instead of the pkg
 
-      .csr_fcsr_fflags_n_i(cv32e40p_top_i.core_i.cs_registers_i.fflags_n),
-      .csr_fcsr_fflags_q_i(cv32e40p_top_i.core_i.cs_registers_i.fflags_q),
-      .csr_fcsr_frm_n_i   (cv32e40p_top_i.core_i.cs_registers_i.frm_n),
-      .csr_fcsr_frm_q_i   (cv32e40p_top_i.core_i.cs_registers_i.frm_q)
+      .csr_fcsr_fflags_n_i (cv32e40p_top_i.core_i.cs_registers_i.fflags_n),
+      .csr_fcsr_fflags_q_i (cv32e40p_top_i.core_i.cs_registers_i.fflags_q),
+      .csr_fcsr_fflags_we_i(cv32e40p_top_i.core_i.cs_registers_i.fflags_we_i),
+      .csr_fcsr_frm_n_i    (cv32e40p_top_i.core_i.cs_registers_i.frm_n),
+      .csr_fcsr_frm_q_i    (cv32e40p_top_i.core_i.cs_registers_i.frm_q)
   );
 `endif
 

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -215,22 +215,22 @@ module cv32e40p_tb_wrapper
 `endif
 
 `ifdef CV32E40P_RVFI
-  logic [ 1:0][31:0] hwlp_start_q;
-  logic [ 1:0][31:0] hwlp_end_q;
-  logic [ 1:0][31:0] hwlp_counter_q;
-  logic [ 1:0][31:0] hwlp_counter_n;
+  logic [1:0][31:0] hwlp_start_q;
+  logic [1:0][31:0] hwlp_end_q;
+  logic [1:0][31:0] hwlp_counter_q;
+  logic [1:0][31:0] hwlp_counter_n;
   generate
-  if(COREV_PULP) begin
+    if (COREV_PULP) begin
       assign hwlp_start_q   = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_start_q  ;
-      assign hwlp_end_q     = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_end_q    ;
+      assign hwlp_end_q = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_end_q;
       assign hwlp_counter_q = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_counter_q;
       assign hwlp_counter_n = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_counter_n;
-  end else begin
+    end else begin
       assign hwlp_start_q   = '0;
       assign hwlp_end_q     = '0;
       assign hwlp_counter_q = '0;
       assign hwlp_counter_n = '0;
-  end
+    end
   endgenerate
 
   cv32e40p_rvfi #(
@@ -281,8 +281,8 @@ module cv32e40p_tb_wrapper
       .debug_csr_save_i  (cv32e40p_top_i.core_i.debug_csr_save),
 
       // HWLOOP regs
-      .hwlp_start_q_i  (hwlp_start_q  ),
-      .hwlp_end_q_i    (hwlp_end_q    ),
+      .hwlp_start_q_i  (hwlp_start_q),
+      .hwlp_end_q_i    (hwlp_end_q),
       .hwlp_counter_q_i(hwlp_counter_q),
       .hwlp_counter_n_i(hwlp_counter_n),
 

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -86,7 +86,7 @@ module cv32e40p_tb_wrapper
     input  logic [31:0] data_rdata_i,
 
     // Interrupt inputs
-    input  logic [31:0] irq_i,  // CLINT interrupts + CLINT extension interrupts
+    input  logic [31:0] irq_i,      // CLINT interrupts + CLINT extension interrupts
     output logic        irq_ack_o,
     output logic [ 4:0] irq_id_o,
 

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -215,6 +215,24 @@ module cv32e40p_tb_wrapper
 `endif
 
 `ifdef CV32E40P_RVFI
+  logic [ 1:0][31:0] hwlp_start_q;
+  logic [ 1:0][31:0] hwlp_end_q;
+  logic [ 1:0][31:0] hwlp_counter_q;
+  logic [ 1:0][31:0] hwlp_counter_n;
+  generate
+  if(COREV_PULP) begin
+      assign hwlp_start_q   = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_start_q  ;
+      assign hwlp_end_q     = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_end_q    ;
+      assign hwlp_counter_q = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_counter_q;
+      assign hwlp_counter_n = cv32e40p_top_i.core_i.id_stage_i.gen_hwloop_regs.hwloop_regs_i.hwlp_counter_n;
+  end else begin
+      assign hwlp_start_q   = '0;
+      assign hwlp_end_q     = '0;
+      assign hwlp_counter_q = '0;
+      assign hwlp_counter_n = '0;
+  end
+  endgenerate
+
   cv32e40p_rvfi #(
       .FPU  (FPU),
       .ZFINX(ZFINX)
@@ -261,6 +279,12 @@ module cv32e40p_tb_wrapper
       .ebrk_insn_dec_i   (cv32e40p_top_i.core_i.id_stage_i.ebrk_insn_dec),
       .csr_cause_i       (cv32e40p_top_i.core_i.csr_cause),
       .debug_csr_save_i  (cv32e40p_top_i.core_i.debug_csr_save),
+
+      // HWLOOP regs
+      .hwlp_start_q_i  (hwlp_start_q  ),
+      .hwlp_end_q_i    (hwlp_end_q    ),
+      .hwlp_counter_q_i(hwlp_counter_q),
+      .hwlp_counter_n_i(hwlp_counter_n),
 
       //// EX probes ////
       .ex_valid_i         (cv32e40p_top_i.core_i.ex_valid),

--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -178,7 +178,7 @@ module cv32e40p_tracer
   end
 
   initial begin
-    wait(rst_n == 1'b1);
+    wait (rst_n == 1'b1);
     $sformat(fn, "trace_core_%h.log", hart_id_i);
     $sformat(info_tag, "CORE_TRACER %2d", hart_id_i);
     $display("[%s] Output filename is: %s", info_tag, fn);
@@ -201,7 +201,7 @@ module cv32e40p_tracer
 
   always @(trace_wb)
     trace_wb_is_delay_instr = (trace_wb != null && is_wb_delay_instr(
-        trace_wb
+      trace_wb
     )) ? 1 : 0;
 
   assign rd  = {rd_is_fp, instr[11:07]};
@@ -214,9 +214,8 @@ module cv32e40p_tracer
     foreach (trace.regs_write[i])
       if (trace.regs_write[i].addr == reg_addr) begin
         trace.regs_write[i].value = wdata;
-        `uvm_info(info_tag, $sformatf(
-                  "Write mapped %0d, %0d:0x%08x pc:0x%08x", i, reg_addr, wdata, trace.pc),
-                  UVM_DEBUG)
+        `uvm_info(info_tag, $sformatf("Write mapped %0d, %0d:0x%08x pc:0x%08x", i, reg_addr, wdata,
+                                      trace.pc), UVM_DEBUG)
       end else begin
         `uvm_info(info_tag, $sformatf(
                   "Unmapped write to %0d:0x%08x, expected write to %0d",
@@ -252,11 +251,11 @@ module cv32e40p_tracer
   // Funnel all handoffs to the ISS here, note that this must be automatic
   // as multiple retire events may occur at a time (wb_bypass)
   always begin
-    wait(trace_q.size() != 0);
+    wait (trace_q.size() != 0);
     trace_retire = trace_q.pop_front();
-    wait(trace_retire.retire != 0);
+    wait (trace_retire.retire != 0);
 
-    if (trace_retire.ebreak) wait(debug_mode == 1);
+    if (trace_retire.ebreak) wait (debug_mode == 1);
 
     // Write signals and data structures used by step-and-compare
     insn_regs_write = trace_retire.regs_write;

--- a/bhv/insn_trace.sv
+++ b/bhv/insn_trace.sv
@@ -108,7 +108,7 @@
     } m_csr;
 
     enum logic[2:0] {
-      IF, ID, EX, WB, WB_2
+      IF, ID, EX, WB, WB_2, APU
     } m_stage;
 
 
@@ -269,10 +269,15 @@
     function void move_down_pipe(insn_trace_t m_source);
       this.copy_full(m_source);
       case(this.m_stage)
-        IF: this.m_stage = ID;
-        ID: this.m_stage = EX;
-        EX: this.m_stage = WB;
-        WB: this.m_stage = WB_2;
+        IF : this.m_stage = ID;
+        ID : this.m_stage = EX;
+        EX : this.m_stage = WB;
+        WB : this.m_stage = WB_2;
+        APU: this.m_stage = APU;
       endcase
+    endfunction
+
+    function void set_to_apu();
+      this.m_stage = APU;
     endfunction
   endclass

--- a/bhv/insn_trace.sv
+++ b/bhv/insn_trace.sv
@@ -36,6 +36,8 @@
     logic       m_dbg_taken;
     logic [2:0] m_dbg_cause;
 
+    logic       m_fflags_we_non_apu;
+    logic       m_frm_we_non_apu;
     logic [5:0] m_rs1_addr;
     logic [5:0] m_rs2_addr;
     logic [31:0] m_rs1_rdata;
@@ -121,27 +123,29 @@
 
 
     function new();
-      this.m_order            = 0;
-      this.m_skip_order       = 1'b0;
-      this.m_valid            = 1'b0;
-      this.m_move_down_pipe   = 1'b0;
-      this.m_data_missaligned = 1'b0;
-      this.m_got_first_data   = 1'b0;
-      this.m_got_ex_reg       = 1'b0;
-      this.m_intr             = '0;
-      this.m_dbg_taken        = 1'b0;
-      this.m_dbg_cause        = '0;
-      this.m_is_ebreak        = '0;
-      this.m_is_illegal       = '0;
-      this.m_is_irq           = '0;
-      this.m_is_memory        = 1'b0;
-      this.m_is_load          = 1'b0;
-      this.m_is_apu           = 1'b0;
-      this.m_is_apu_ok        = 1'b0;
-      this.m_apu_req_id       = 0;
-      this.m_mem_req_id[0]    = 0;
-      this.m_mem_req_id[1]    = 0;
-      this.m_trap             = 1'b0;
+      this.m_order             = 0;
+      this.m_skip_order        = 1'b0;
+      this.m_valid             = 1'b0;
+      this.m_move_down_pipe    = 1'b0;
+      this.m_data_missaligned  = 1'b0;
+      this.m_got_first_data    = 1'b0;
+      this.m_got_ex_reg        = 1'b0;
+      this.m_intr              = '0;
+      this.m_dbg_taken         = 1'b0;
+      this.m_dbg_cause         = '0;
+      this.m_is_ebreak         = '0;
+      this.m_is_illegal        = '0;
+      this.m_is_irq            = '0;
+      this.m_is_memory         = 1'b0;
+      this.m_is_load           = 1'b0;
+      this.m_is_apu            = 1'b0;
+      this.m_is_apu_ok         = 1'b0;
+      this.m_apu_req_id        = 0;
+      this.m_mem_req_id[0]     = 0;
+      this.m_mem_req_id[1]     = 0;
+      this.m_trap              = 1'b0;
+      this.m_fflags_we_non_apu = 1'b0;
+      this.m_frm_we_non_apu    = 1'b0;
     endfunction
 
     /*
@@ -154,32 +158,33 @@
       if(this.m_skip_order) begin
         this.m_order            = this.m_order + 64'h1;
       end
-      this.m_skip_order       = 1'b0;
-      this.m_pc_rdata         = r_pipe_freeze_trace.pc_id;
-      this.m_is_illegal       = 1'b0;
-      this.m_is_irq           = 1'b0;
-      this.m_is_memory        = 1'b0;
-      this.m_is_load          = 1'b0;
-      this.m_is_apu           = 1'b0;
-      this.m_is_apu_ok        = 1'b0;
-      this.m_apu_req_id       = 0;
-      this.m_mem_req_id[0]    = 0;
-      this.m_mem_req_id[1]    = 0;
-      this.m_data_missaligned = 1'b0;
-      this.m_got_first_data   = 1'b0;
-      this.m_got_ex_reg       = 1'b0;
-      this.m_got_regs_write   = 1'b0;
-      this.m_move_down_pipe   = 1'b0;
-      this.m_rd_addr[0]       = '0;
-      this.m_rd_addr[1]       = '0;
-      this.m_2_rd_insn        = 1'b0;
-      this.m_rs1_addr         = '0;
-      this.m_rs2_addr         = '0;
-      this.m_ex_fw            = '0;
-      this.m_csr.got_minstret = '0;
-      this.m_dbg_taken        = '0;
-      this.m_trap             = 1'b0;
-
+      this.m_skip_order        = 1'b0;
+      this.m_pc_rdata          = r_pipe_freeze_trace.pc_id;
+      this.m_is_illegal        = 1'b0;
+      this.m_is_irq            = 1'b0;
+      this.m_is_memory         = 1'b0;
+      this.m_is_load           = 1'b0;
+      this.m_is_apu            = 1'b0;
+      this.m_is_apu_ok         = 1'b0;
+      this.m_apu_req_id        = 0;
+      this.m_mem_req_id[0]     = 0;
+      this.m_mem_req_id[1]     = 0;
+      this.m_data_missaligned  = 1'b0;
+      this.m_got_first_data    = 1'b0;
+      this.m_got_ex_reg        = 1'b0;
+      this.m_got_regs_write    = 1'b0;
+      this.m_move_down_pipe    = 1'b0;
+      this.m_rd_addr[0]        = '0;
+      this.m_rd_addr[1]        = '0;
+      this.m_2_rd_insn         = 1'b0;
+      this.m_rs1_addr          = '0;
+      this.m_rs2_addr          = '0;
+      this.m_ex_fw             = '0;
+      this.m_csr.got_minstret  = '0;
+      this.m_dbg_taken         = '0;
+      this.m_trap              = 1'b0;
+      this.m_fflags_we_non_apu = 1'b0;
+      this.m_frm_we_non_apu    = 1'b0;
       this.m_csr.mcause_we = '0;
       if (is_compressed_id_i) begin
         this.m_insn[31:16] = '0;
@@ -244,6 +249,8 @@
 
       this.m_intr               = m_source.m_intr;
       this.m_trap               = m_source.m_trap;
+      this.m_fflags_we_non_apu  = m_source.m_fflags_we_non_apu;
+      this.m_frm_we_non_apu     = m_source.m_frm_we_non_apu   ;
 
       this.m_mem                = m_source.m_mem;
       //CRS

--- a/bhv/insn_trace.sv
+++ b/bhv/insn_trace.sv
@@ -105,6 +105,14 @@
       `DEFINE_CSR(fflags)
       `DEFINE_CSR(frm   )
       `DEFINE_CSR(fcsr  )
+
+      `DEFINE_CSR(lpstart0 )
+      `DEFINE_CSR(lpend0   )
+      `DEFINE_CSR(lpcount0 )
+      `DEFINE_CSR(lpstart1 )
+      `DEFINE_CSR(lpend1   )
+      `DEFINE_CSR(lpcount1 )
+
     } m_csr;
 
     enum logic[2:0] {
@@ -263,6 +271,13 @@
       `ASSIGN_CSR(fflags)
       `ASSIGN_CSR(frm   )
       `ASSIGN_CSR(fcsr  )
+
+      `ASSIGN_CSR(lpstart0)
+      `ASSIGN_CSR(lpend0  )
+      `ASSIGN_CSR(lpcount0)
+      `ASSIGN_CSR(lpstart1)
+      `ASSIGN_CSR(lpend1  )
+      `ASSIGN_CSR(lpcount1)
 
     endfunction
 

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -312,10 +312,10 @@ typedef struct {
 
   } csr;
   struct {
-      logic [ 1:0][31:0] start_q;
-      logic [ 1:0][31:0] end_q;
-      logic [ 1:0][31:0] counter_q;
-      logic [ 1:0][31:0] counter_n;
+    logic [1:0][31:0] start_q;
+    logic [1:0][31:0] end_q;
+    logic [1:0][31:0] counter_q;
+    logic [1:0][31:0] counter_n;
   } hwloop;
 } pipe_trace_t;
 

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -89,6 +89,10 @@ typedef struct {
   logic [31:0] ex_reg_wdata;
 
   logic apu_en_ex;
+  logic apu_singlecycle;
+  logic apu_multicycle;
+  logic wb_contention_lsu;
+  logic wb_contention;
 
   logic branch_in_ex;
   logic branch_decision_ex;
@@ -352,149 +356,153 @@ task monitor_pipeline();
     wait(clk_i_d == 1'b0 & rst_ni == 1'b1);
     // r_pipe_freeze_trace. <= ;
 
-    r_pipe_freeze_trace.instr_req = instr_req_i;
-    r_pipe_freeze_trace.instr_grant = instr_grant_i;
-    r_pipe_freeze_trace.instr_rvalid = instr_rvalid_i;
-    r_pipe_freeze_trace.is_decoding = is_decoding_i;
-    r_pipe_freeze_trace.is_illegal = is_illegal_i;
-    r_pipe_freeze_trace.trigger_match = trigger_match_i;
-    r_pipe_freeze_trace.data_misaligned = data_misaligned_i;
-    r_pipe_freeze_trace.lsu_data_we_ex = lsu_data_we_ex_i;
+    r_pipe_freeze_trace.instr_req             = instr_req_i;
+    r_pipe_freeze_trace.instr_grant           = instr_grant_i;
+    r_pipe_freeze_trace.instr_rvalid          = instr_rvalid_i;
+    r_pipe_freeze_trace.is_decoding           = is_decoding_i;
+    r_pipe_freeze_trace.is_illegal            = is_illegal_i;
+    r_pipe_freeze_trace.trigger_match         = trigger_match_i;
+    r_pipe_freeze_trace.data_misaligned       = data_misaligned_i;
+    r_pipe_freeze_trace.lsu_data_we_ex        = lsu_data_we_ex_i;
 
-    r_pipe_freeze_trace.debug_mode = debug_mode_i;
-    r_pipe_freeze_trace.debug_cause = debug_cause_i;
-    r_pipe_freeze_trace.prefetch_req = prefetch_req_i;
-    r_pipe_freeze_trace.pc_set = pc_set_i;
+    r_pipe_freeze_trace.debug_mode            = debug_mode_i;
+    r_pipe_freeze_trace.debug_cause           = debug_cause_i;
+    r_pipe_freeze_trace.prefetch_req          = prefetch_req_i;
+    r_pipe_freeze_trace.pc_set                = pc_set_i;
     //// IF probes ////
-    r_pipe_freeze_trace.if_valid = if_valid_i;
-    r_pipe_freeze_trace.if_ready = if_ready_i;
-    r_pipe_freeze_trace.instr_valid_if = instr_valid_if_i;
-    r_pipe_freeze_trace.instr_if = instr_if_i;
-    r_pipe_freeze_trace.pc_if = pc_if_i;
-    r_pipe_freeze_trace.instr_pmp_err_if = instr_pmp_err_if_i;
+    r_pipe_freeze_trace.if_valid              = if_valid_i;
+    r_pipe_freeze_trace.if_ready              = if_ready_i;
+    r_pipe_freeze_trace.instr_valid_if        = instr_valid_if_i;
+    r_pipe_freeze_trace.instr_if              = instr_if_i;
+    r_pipe_freeze_trace.pc_if                 = pc_if_i;
+    r_pipe_freeze_trace.instr_pmp_err_if      = instr_pmp_err_if_i;
 
-    r_pipe_freeze_trace.instr_valid_id = instr_valid_id_i;
-    r_pipe_freeze_trace.instr_rdata_id = instr_rdata_id_i;
-    r_pipe_freeze_trace.is_fetch_failed_id = is_fetch_failed_id_i;
-    r_pipe_freeze_trace.instr_req_int = instr_req_int_i;
-    r_pipe_freeze_trace.clear_instr_valid = clear_instr_valid_i;
+    r_pipe_freeze_trace.instr_valid_id        = instr_valid_id_i;
+    r_pipe_freeze_trace.instr_rdata_id        = instr_rdata_id_i;
+    r_pipe_freeze_trace.is_fetch_failed_id    = is_fetch_failed_id_i;
+    r_pipe_freeze_trace.instr_req_int         = instr_req_int_i;
+    r_pipe_freeze_trace.clear_instr_valid     = clear_instr_valid_i;
     //// ID probes ////
-    r_pipe_freeze_trace.pc_id = pc_id_i;
-    r_pipe_freeze_trace.id_valid = id_valid_i;
+    r_pipe_freeze_trace.pc_id                 = pc_id_i;
+    r_pipe_freeze_trace.id_valid              = id_valid_i;
 
-    r_pipe_freeze_trace.id_ready = id_ready_i;
-    r_pipe_freeze_trace.rf_re_id = rf_re_id_i;
-    r_pipe_freeze_trace.sys_en_id = sys_en_id_i;
-    r_pipe_freeze_trace.sys_mret_insn_id = sys_mret_insn_id_i;
-    r_pipe_freeze_trace.jump_in_id = jump_in_id_i;
-    r_pipe_freeze_trace.jump_target_id = jump_target_id_i;
-    r_pipe_freeze_trace.is_compressed_id = is_compressed_id_i;
-    r_pipe_freeze_trace.ebrk_insn_dec = ebrk_insn_dec_i;
-    r_pipe_freeze_trace.csr_cause = csr_cause_i;
-    r_pipe_freeze_trace.debug_csr_save = debug_csr_save_i;
+    r_pipe_freeze_trace.id_ready              = id_ready_i;
+    r_pipe_freeze_trace.rf_re_id              = rf_re_id_i;
+    r_pipe_freeze_trace.sys_en_id             = sys_en_id_i;
+    r_pipe_freeze_trace.sys_mret_insn_id      = sys_mret_insn_id_i;
+    r_pipe_freeze_trace.jump_in_id            = jump_in_id_i;
+    r_pipe_freeze_trace.jump_target_id        = jump_target_id_i;
+    r_pipe_freeze_trace.is_compressed_id      = is_compressed_id_i;
+    r_pipe_freeze_trace.ebrk_insn_dec         = ebrk_insn_dec_i;
+    r_pipe_freeze_trace.csr_cause             = csr_cause_i;
+    r_pipe_freeze_trace.debug_csr_save        = debug_csr_save_i;
     // LSU
-    r_pipe_freeze_trace.lsu_en_id = lsu_en_id_i;
-    r_pipe_freeze_trace.lsu_we_id = lsu_we_id_i;
-    r_pipe_freeze_trace.lsu_size_id = lsu_size_id_i;
+    r_pipe_freeze_trace.lsu_en_id             = lsu_en_id_i;
+    r_pipe_freeze_trace.lsu_we_id             = lsu_we_id_i;
+    r_pipe_freeze_trace.lsu_size_id           = lsu_size_id_i;
     // Register reads
-    r_pipe_freeze_trace.rs1_addr_id = rs1_addr_id_i;
-    r_pipe_freeze_trace.rs2_addr_id = rs2_addr_id_i;
-    r_pipe_freeze_trace.operand_a_fw_id = operand_a_fw_id_i;
-    r_pipe_freeze_trace.operand_b_fw_id = operand_b_fw_id_i;
+    r_pipe_freeze_trace.rs1_addr_id           = rs1_addr_id_i;
+    r_pipe_freeze_trace.rs2_addr_id           = rs2_addr_id_i;
+    r_pipe_freeze_trace.operand_a_fw_id       = operand_a_fw_id_i;
+    r_pipe_freeze_trace.operand_b_fw_id       = operand_b_fw_id_i;
 
     //// EX probes ////
 
     // Register writes in EX
-    r_pipe_freeze_trace.ex_ready = ex_ready_i;
-    r_pipe_freeze_trace.ex_valid = ex_valid_i;
+    r_pipe_freeze_trace.ex_ready              = ex_ready_i;
+    r_pipe_freeze_trace.ex_valid              = ex_valid_i;
 
-    r_pipe_freeze_trace.ex_reg_we = ex_reg_we_i;
-    r_pipe_freeze_trace.ex_reg_addr = ex_reg_addr_i;
-    r_pipe_freeze_trace.ex_reg_wdata = ex_reg_wdata_i;
+    r_pipe_freeze_trace.ex_reg_we             = ex_reg_we_i;
+    r_pipe_freeze_trace.ex_reg_addr           = ex_reg_addr_i;
+    r_pipe_freeze_trace.ex_reg_wdata          = ex_reg_wdata_i;
 
-    r_pipe_freeze_trace.apu_en_ex = apu_en_ex_i;
+    r_pipe_freeze_trace.apu_en_ex             = apu_en_ex_i;
+    r_pipe_freeze_trace.apu_singlecycle       = apu_singlecycle_i;
+    r_pipe_freeze_trace.apu_multicycle        = apu_multicycle_i;
+    r_pipe_freeze_trace.wb_contention_lsu     = wb_contention_lsu_i;
+    r_pipe_freeze_trace.wb_contention         = wb_contention_i;
 
-    r_pipe_freeze_trace.branch_in_ex = branch_in_ex_i;
-    r_pipe_freeze_trace.branch_decision_ex = branch_decision_ex_i;
-    r_pipe_freeze_trace.dret_in_ex = dret_in_ex_i;
+    r_pipe_freeze_trace.branch_in_ex          = branch_in_ex_i;
+    r_pipe_freeze_trace.branch_decision_ex    = branch_decision_ex_i;
+    r_pipe_freeze_trace.dret_in_ex            = dret_in_ex_i;
     // LSU
-    r_pipe_freeze_trace.lsu_en_ex = lsu_en_ex_i;
-    r_pipe_freeze_trace.lsu_pmp_err_ex = lsu_pmp_err_ex_i;
+    r_pipe_freeze_trace.lsu_en_ex             = lsu_en_ex_i;
+    r_pipe_freeze_trace.lsu_pmp_err_ex        = lsu_pmp_err_ex_i;
     r_pipe_freeze_trace.lsu_pma_err_atomic_ex = lsu_pma_err_atomic_ex_i;
 
-    r_pipe_freeze_trace.branch_target_ex = branch_target_ex_i;
+    r_pipe_freeze_trace.branch_target_ex      = branch_target_ex_i;
 
-    r_pipe_freeze_trace.data_addr_ex = data_addr_ex_i;
-    r_pipe_freeze_trace.data_wdata_ex = data_wdata_ex_i;
-    r_pipe_freeze_trace.lsu_split_q_ex = lsu_split_q_ex_i;
+    r_pipe_freeze_trace.data_addr_ex          = data_addr_ex_i;
+    r_pipe_freeze_trace.data_wdata_ex         = data_wdata_ex_i;
+    r_pipe_freeze_trace.lsu_split_q_ex        = lsu_split_q_ex_i;
 
     //// WB probes ////
-    r_pipe_freeze_trace.pc_wb = pc_wb_i;
-    r_pipe_freeze_trace.wb_ready = wb_ready_i;
-    r_pipe_freeze_trace.wb_valid = wb_valid_i;
-    r_pipe_freeze_trace.ebreak_in_wb = ebreak_in_wb_i;
-    r_pipe_freeze_trace.instr_rdata_wb = instr_rdata_wb_i;
-    r_pipe_freeze_trace.csr_en_wb = csr_en_wb_i;
-    r_pipe_freeze_trace.sys_wfi_insn_wb = sys_wfi_insn_wb_i;
+    r_pipe_freeze_trace.pc_wb                 = pc_wb_i;
+    r_pipe_freeze_trace.wb_ready              = wb_ready_i;
+    r_pipe_freeze_trace.wb_valid              = wb_valid_i;
+    r_pipe_freeze_trace.ebreak_in_wb          = ebreak_in_wb_i;
+    r_pipe_freeze_trace.instr_rdata_wb        = instr_rdata_wb_i;
+    r_pipe_freeze_trace.csr_en_wb             = csr_en_wb_i;
+    r_pipe_freeze_trace.sys_wfi_insn_wb       = sys_wfi_insn_wb_i;
     // Register writes
-    r_pipe_freeze_trace.rf_we_wb = rf_we_wb_i;
-    r_pipe_freeze_trace.rf_addr_wb = rf_addr_wb_i;
-    r_pipe_freeze_trace.rf_wdata_wb = rf_wdata_wb_i;
+    r_pipe_freeze_trace.rf_we_wb              = rf_we_wb_i;
+    r_pipe_freeze_trace.rf_addr_wb            = rf_addr_wb_i;
+    r_pipe_freeze_trace.rf_wdata_wb           = rf_wdata_wb_i;
     // LSU
-    r_pipe_freeze_trace.lsu_rdata_wb = lsu_rdata_wb_i;
+    r_pipe_freeze_trace.lsu_rdata_wb          = lsu_rdata_wb_i;
 
-    r_pipe_freeze_trace.data_we_ex = data_we_ex_i;
-    r_pipe_freeze_trace.data_atop_ex = data_atop_ex_i;
-    r_pipe_freeze_trace.data_type_ex = data_type_ex_i;
-    r_pipe_freeze_trace.alu_operand_c_ex = alu_operand_c_ex_i;
-    r_pipe_freeze_trace.data_reg_offset_ex = data_reg_offset_ex_i;
-    r_pipe_freeze_trace.data_load_event_ex = data_load_event_ex_i;
-    r_pipe_freeze_trace.data_sign_ext_ex = data_sign_ext_ex_i;
-    r_pipe_freeze_trace.lsu_rdata = lsu_rdata_i;
-    r_pipe_freeze_trace.data_req_ex = data_req_ex_i;
-    r_pipe_freeze_trace.alu_operand_a_ex = alu_operand_a_ex_i;
-    r_pipe_freeze_trace.alu_operand_b_ex = alu_operand_b_ex_i;
-    r_pipe_freeze_trace.useincr_addr_ex = useincr_addr_ex_i;
-    r_pipe_freeze_trace.data_misaligned_ex = data_misaligned_ex_i;
-    r_pipe_freeze_trace.p_elw_start = p_elw_start_i;
-    r_pipe_freeze_trace.p_elw_finish = p_elw_finish_i;
-    r_pipe_freeze_trace.lsu_ready_ex = lsu_ready_ex_i;
-    r_pipe_freeze_trace.lsu_ready_wb = lsu_ready_wb_i;
+    r_pipe_freeze_trace.data_we_ex            = data_we_ex_i;
+    r_pipe_freeze_trace.data_atop_ex          = data_atop_ex_i;
+    r_pipe_freeze_trace.data_type_ex          = data_type_ex_i;
+    r_pipe_freeze_trace.alu_operand_c_ex      = alu_operand_c_ex_i;
+    r_pipe_freeze_trace.data_reg_offset_ex    = data_reg_offset_ex_i;
+    r_pipe_freeze_trace.data_load_event_ex    = data_load_event_ex_i;
+    r_pipe_freeze_trace.data_sign_ext_ex      = data_sign_ext_ex_i;
+    r_pipe_freeze_trace.lsu_rdata             = lsu_rdata_i;
+    r_pipe_freeze_trace.data_req_ex           = data_req_ex_i;
+    r_pipe_freeze_trace.alu_operand_a_ex      = alu_operand_a_ex_i;
+    r_pipe_freeze_trace.alu_operand_b_ex      = alu_operand_b_ex_i;
+    r_pipe_freeze_trace.useincr_addr_ex       = useincr_addr_ex_i;
+    r_pipe_freeze_trace.data_misaligned_ex    = data_misaligned_ex_i;
+    r_pipe_freeze_trace.p_elw_start           = p_elw_start_i;
+    r_pipe_freeze_trace.p_elw_finish          = p_elw_finish_i;
+    r_pipe_freeze_trace.lsu_ready_ex          = lsu_ready_ex_i;
+    r_pipe_freeze_trace.lsu_ready_wb          = lsu_ready_wb_i;
 
-    r_pipe_freeze_trace.data_req_pmp = data_req_pmp_i;
-    r_pipe_freeze_trace.data_gnt_pmp = data_gnt_pmp_i;
-    r_pipe_freeze_trace.data_rvalid = data_rvalid_i;
-    r_pipe_freeze_trace.data_err_pmp = data_err_pmp_i;
-    r_pipe_freeze_trace.data_addr_pmp = data_addr_pmp_i;
-    r_pipe_freeze_trace.data_we = data_we_i;
-    r_pipe_freeze_trace.data_atop = data_atop_i;
-    r_pipe_freeze_trace.data_be = data_be_i;
-    r_pipe_freeze_trace.data_wdata = data_wdata_i;
-    r_pipe_freeze_trace.data_rdata = data_rdata_i;
+    r_pipe_freeze_trace.data_req_pmp          = data_req_pmp_i;
+    r_pipe_freeze_trace.data_gnt_pmp          = data_gnt_pmp_i;
+    r_pipe_freeze_trace.data_rvalid           = data_rvalid_i;
+    r_pipe_freeze_trace.data_err_pmp          = data_err_pmp_i;
+    r_pipe_freeze_trace.data_addr_pmp         = data_addr_pmp_i;
+    r_pipe_freeze_trace.data_we               = data_we_i;
+    r_pipe_freeze_trace.data_atop             = data_atop_i;
+    r_pipe_freeze_trace.data_be               = data_be_i;
+    r_pipe_freeze_trace.data_wdata            = data_wdata_i;
+    r_pipe_freeze_trace.data_rdata            = data_rdata_i;
 
     //// APU ////
-    r_pipe_freeze_trace.apu_req = apu_req_i;
-    r_pipe_freeze_trace.apu_gnt = apu_gnt_i;
-    r_pipe_freeze_trace.apu_rvalid = apu_rvalid_i;
+    r_pipe_freeze_trace.apu_req               = apu_req_i;
+    r_pipe_freeze_trace.apu_gnt               = apu_gnt_i;
+    r_pipe_freeze_trace.apu_rvalid            = apu_rvalid_i;
 
     // PC //
-    r_pipe_freeze_trace.branch_addr_n = branch_addr_n_i;
+    r_pipe_freeze_trace.branch_addr_n         = branch_addr_n_i;
 
     // Controller FSM probes
-    r_pipe_freeze_trace.ctrl_fsm_cs = ctrl_fsm_cs_i;
-    r_pipe_freeze_trace.pc_mux = pc_mux_i;
-    r_pipe_freeze_trace.exc_pc_mux = exc_pc_mux_i;
+    r_pipe_freeze_trace.ctrl_fsm_cs           = ctrl_fsm_cs_i;
+    r_pipe_freeze_trace.pc_mux                = pc_mux_i;
+    r_pipe_freeze_trace.exc_pc_mux            = exc_pc_mux_i;
 
     // CSR
-    r_pipe_freeze_trace.csr.addr = csr_addr_i;
-    r_pipe_freeze_trace.csr.we = csr_we_i;
-    r_pipe_freeze_trace.csr.wdata_int = csr_wdata_int_i;
+    r_pipe_freeze_trace.csr.addr              = csr_addr_i;
+    r_pipe_freeze_trace.csr.we                = csr_we_i;
+    r_pipe_freeze_trace.csr.wdata_int         = csr_wdata_int_i;
 
-    r_pipe_freeze_trace.csr.jvt_we = csr_jvt_we_i;
-    r_pipe_freeze_trace.csr.mstatus_n = csr_mstatus_n_i;
-    r_pipe_freeze_trace.csr.mstatus_q = csr_mstatus_q_i;
-    r_pipe_freeze_trace.csr.mstatus_fs_n = csr_mstatus_fs_n_i;
-    r_pipe_freeze_trace.csr.mstatus_fs_q = csr_mstatus_fs_q_i;
+    r_pipe_freeze_trace.csr.jvt_we            = csr_jvt_we_i;
+    r_pipe_freeze_trace.csr.mstatus_n         = csr_mstatus_n_i;
+    r_pipe_freeze_trace.csr.mstatus_q         = csr_mstatus_q_i;
+    r_pipe_freeze_trace.csr.mstatus_fs_n      = csr_mstatus_fs_n_i;
+    r_pipe_freeze_trace.csr.mstatus_fs_q      = csr_mstatus_fs_q_i;
 
     if (FPU == 1 && ZFINX == 0) begin
       r_pipe_freeze_trace.csr.mstatus_full_q[31] = (r_pipe_freeze_trace.csr.mstatus_fs_q == FS_DIRTY) ? 1'b1 : 1'b0;
@@ -648,6 +656,10 @@ task monitor_pipeline();
     r_pipe_freeze_trace.csr.fcsr_q = {24'b0, csr_fcsr_frm_q_i, csr_fcsr_fflags_q_i};
 
     compute_csr_we();
+    if (csr_fcsr_fflags_we_i) begin
+      r_pipe_freeze_trace.csr.fflags_we = 1'b1;
+      r_pipe_freeze_trace.csr.fcsr_we   = 1'b1;
+    end
 
     // #1;
     ->e_pipe_monitor_ok;

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -311,6 +311,12 @@ typedef struct {
     logic fcsr_we;
 
   } csr;
+  struct {
+      logic [ 1:0][31:0] start_q;
+      logic [ 1:0][31:0] end_q;
+      logic [ 1:0][31:0] counter_q;
+      logic [ 1:0][31:0] counter_n;
+  } hwloop;
 } pipe_trace_t;
 
 pipe_trace_t r_pipe_freeze_trace;
@@ -660,6 +666,11 @@ task monitor_pipeline();
       r_pipe_freeze_trace.csr.fflags_we = 1'b1;
       r_pipe_freeze_trace.csr.fcsr_we   = 1'b1;
     end
+
+    r_pipe_freeze_trace.hwloop.start_q   = hwlp_start_q_i  ;
+    r_pipe_freeze_trace.hwloop.end_q     = hwlp_end_q_i    ;
+    r_pipe_freeze_trace.hwloop.counter_q = hwlp_counter_q_i;
+    r_pipe_freeze_trace.hwloop.counter_n = hwlp_counter_n_i;
 
     // #1;
     ->e_pipe_monitor_ok;

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -656,15 +656,16 @@ task monitor_pipeline();
 
     r_pipe_freeze_trace.csr.fflags_n = {27'b0, csr_fcsr_fflags_n_i};
     r_pipe_freeze_trace.csr.fflags_q = {27'b0, csr_fcsr_fflags_q_i};
-    r_pipe_freeze_trace.csr.frm_n = {29'b0, csr_fcsr_frm_n_i};
-    r_pipe_freeze_trace.csr.frm_q = {29'b0, csr_fcsr_frm_q_i};
+    r_pipe_freeze_trace.csr.frm_n = {28'b0, csr_fcsr_frm_n_i};
+    r_pipe_freeze_trace.csr.frm_q = {28'b0, csr_fcsr_frm_q_i};
     r_pipe_freeze_trace.csr.fcsr_n = {24'b0, csr_fcsr_frm_n_i, csr_fcsr_fflags_n_i};
     r_pipe_freeze_trace.csr.fcsr_q = {24'b0, csr_fcsr_frm_q_i, csr_fcsr_fflags_q_i};
 
     compute_csr_we();
     if (csr_fcsr_fflags_we_i) begin
-      r_pipe_freeze_trace.csr.fflags_we = 1'b1;
-      r_pipe_freeze_trace.csr.fcsr_we   = 1'b1;
+      r_pipe_freeze_trace.csr.fflags_we  = 1'b1;
+      r_pipe_freeze_trace.csr.fcsr_we    = 1'b1;
+      r_pipe_freeze_trace.csr.mstatus_we = 1'b1;
     end
 
     r_pipe_freeze_trace.hwloop.start_q   = hwlp_start_q_i;

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -359,7 +359,7 @@ endfunction
 task monitor_pipeline();
   $display("*****Starting pipeline monitoring*****\n");
   forever begin
-    wait(clk_i_d == 1'b0 & rst_ni == 1'b1);
+    wait (clk_i_d == 1'b0 & rst_ni == 1'b1);
     // r_pipe_freeze_trace. <= ;
 
     r_pipe_freeze_trace.instr_req             = instr_req_i;
@@ -667,13 +667,13 @@ task monitor_pipeline();
       r_pipe_freeze_trace.csr.fcsr_we   = 1'b1;
     end
 
-    r_pipe_freeze_trace.hwloop.start_q   = hwlp_start_q_i  ;
-    r_pipe_freeze_trace.hwloop.end_q     = hwlp_end_q_i    ;
+    r_pipe_freeze_trace.hwloop.start_q   = hwlp_start_q_i;
+    r_pipe_freeze_trace.hwloop.end_q     = hwlp_end_q_i;
     r_pipe_freeze_trace.hwloop.counter_q = hwlp_counter_q_i;
     r_pipe_freeze_trace.hwloop.counter_n = hwlp_counter_n_i;
 
     // #1;
     ->e_pipe_monitor_ok;
-    wait(clk_i_d == 1'b1);
+    wait (clk_i_d == 1'b1);
   end
 endtask

--- a/rtl/cv32e40p_aligner.sv
+++ b/rtl/cv32e40p_aligner.sv
@@ -25,7 +25,7 @@ module cv32e40p_aligner (
     input logic rst_n,
 
     input  logic fetch_valid_i,
-    output logic aligner_ready_o,  //prevents overwriting the fethced instruction
+    output logic aligner_ready_o, //prevents overwriting the fethced instruction
 
     input logic if_valid_i,
 
@@ -34,7 +34,7 @@ module cv32e40p_aligner (
     output logic        instr_valid_o,
 
     input logic [31:0] branch_addr_i,
-    input logic        branch_i,  // Asserted if we are branching/jumping now
+    input logic        branch_i,       // Asserted if we are branching/jumping now
 
     input logic [31:0] hwlp_addr_i,
     input logic        hwlp_update_pc_i,

--- a/rtl/cv32e40p_alu.sv
+++ b/rtl/cv32e40p_alu.sv
@@ -263,36 +263,28 @@ module cv32e40p_alu
   // right shifts, we let the synthesizer optimize this
   logic [63:0] shift_op_a_32;
 
-  assign shift_op_a_32 = (operator_i == ALU_ROR) ? {
-        shift_op_a, shift_op_a
-      } : $signed(
-          {{32{shift_arithmetic & shift_op_a[31]}}, shift_op_a}
-      );
+  assign shift_op_a_32 = (operator_i == ALU_ROR) ? {shift_op_a, shift_op_a} : $signed(
+      {{32{shift_arithmetic & shift_op_a[31]}}, shift_op_a}
+  );
 
   always_comb begin
     case (vector_mode_i)
       VEC_MODE16: begin
-        shift_right_result[31:16] = $signed(
-            {shift_arithmetic & shift_op_a[31], shift_op_a[31:16]}
-        ) >>> shift_amt_int[19:16];
-        shift_right_result[15:0] = $signed(
-            {shift_arithmetic & shift_op_a[15], shift_op_a[15:0]}
-        ) >>> shift_amt_int[3:0];
+        shift_right_result[31:16] = $signed({shift_arithmetic & shift_op_a[31],
+                                             shift_op_a[31:16]}) >>> shift_amt_int[19:16];
+        shift_right_result[15:0] =
+            $signed({shift_arithmetic & shift_op_a[15], shift_op_a[15:0]}) >>> shift_amt_int[3:0];
       end
 
       VEC_MODE8: begin
-        shift_right_result[31:24] = $signed(
-            {shift_arithmetic & shift_op_a[31], shift_op_a[31:24]}
-        ) >>> shift_amt_int[26:24];
-        shift_right_result[23:16] = $signed(
-            {shift_arithmetic & shift_op_a[23], shift_op_a[23:16]}
-        ) >>> shift_amt_int[18:16];
-        shift_right_result[15:8] = $signed(
-            {shift_arithmetic & shift_op_a[15], shift_op_a[15:8]}
-        ) >>> shift_amt_int[10:8];
-        shift_right_result[7:0] = $signed(
-            {shift_arithmetic & shift_op_a[7], shift_op_a[7:0]}
-        ) >>> shift_amt_int[2:0];
+        shift_right_result[31:24] = $signed({shift_arithmetic & shift_op_a[31],
+                                             shift_op_a[31:24]}) >>> shift_amt_int[26:24];
+        shift_right_result[23:16] = $signed({shift_arithmetic & shift_op_a[23],
+                                             shift_op_a[23:16]}) >>> shift_amt_int[18:16];
+        shift_right_result[15:8] =
+            $signed({shift_arithmetic & shift_op_a[15], shift_op_a[15:8]}) >>> shift_amt_int[10:8];
+        shift_right_result[7:0] = $signed({shift_arithmetic & shift_op_a[7], shift_op_a[7:0]}) >>>
+            shift_amt_int[2:0];
       end
 
       default: // VEC_MODE32

--- a/rtl/cv32e40p_alu_div.sv
+++ b/rtl/cv32e40p_alu_div.sv
@@ -35,8 +35,8 @@ module cv32e40p_alu_div #(
     input  logic [C_LOG_WIDTH-1:0] OpBShift_DI,
     input  logic                   OpBIsZero_SI,
     //
-    input  logic                   OpBSign_SI,  // gate this to 0 in case of unsigned ops
-    input  logic [            1:0] OpCode_SI,  // 0: udiv, 2: urem, 1: div, 3: rem
+    input  logic                   OpBSign_SI,    // gate this to 0 in case of unsigned ops
+    input  logic [            1:0] OpCode_SI,     // 0: udiv, 2: urem, 1: div, 3: rem
     // handshake
     input  logic                   InVld_SI,
     // output IF
@@ -186,9 +186,9 @@ module cv32e40p_alu_div #(
 
   assign AReg_DN = (ARegEn_S) ? AddOut_D : AReg_DP;
   assign BReg_DN = (BRegEn_S) ? BMux_D : BReg_DP;
-  assign ResReg_DN = (LoadEn_S) ? '0 : (ResRegEn_S) ? {
-    ABComp_S, ResReg_DP[$high(ResReg_DP):1]
-  } : ResReg_DP;
+  assign ResReg_DN = (LoadEn_S) ? '0 : (ResRegEn_S) ? {ABComp_S, ResReg_DP[$high(
+      ResReg_DP
+  ):1]} : ResReg_DP;
 
   always_ff @(posedge Clk_CI or negedge Rst_RBI) begin : p_regs
     if (~Rst_RBI) begin

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -84,7 +84,7 @@ module cv32e40p_core
     input  logic [APU_NUSFLAGS_CPU-1:0]       apu_flags_i,
 
     // Interrupt inputs
-    input  logic [31:0] irq_i,  // CLINT interrupts + CLINT extension interrupts
+    input  logic [31:0] irq_i,      // CLINT interrupts + CLINT extension interrupts
     output logic        irq_ack_o,
     output logic [ 4:0] irq_id_o,
 
@@ -379,9 +379,9 @@ module cv32e40p_core
       .COREV_CLUSTER(COREV_CLUSTER)
   ) sleep_unit_i (
       // Clock, reset interface
-      .clk_ungated_i(clk_i),  // Ungated clock
+      .clk_ungated_i(clk_i),        // Ungated clock
       .rst_n        (rst_ni),
-      .clk_gated_o  (clk),  // Gated clock
+      .clk_gated_o  (clk),          // Gated clock
       .scan_cg_en_i (scan_cg_en_i),
 
       // Core sleep
@@ -447,8 +447,8 @@ module cv32e40p_core
       .instr_gnt_i    (instr_gnt_pmp),
       .instr_rvalid_i (instr_rvalid_i),
       .instr_rdata_i  (instr_rdata_i),
-      .instr_err_i    (1'b0),  // Bus error (not used yet)
-      .instr_err_pmp_i(instr_err_pmp),  // PMP error
+      .instr_err_i    (1'b0),            // Bus error (not used yet)
+      .instr_err_pmp_i(instr_err_pmp),   // PMP error
 
       // outputs to ID stage
       .instr_valid_id_o (instr_valid_id),
@@ -464,7 +464,7 @@ module cv32e40p_core
 
       .depc_i(depc),  // debug return address
 
-      .pc_mux_i    (pc_mux_id),  // sel for pc multiplexer
+      .pc_mux_i    (pc_mux_id),     // sel for pc multiplexer
       .exc_pc_mux_i(exc_pc_mux_id),
 
 
@@ -523,7 +523,7 @@ module cv32e40p_core
       .APU_NUSFLAGS_CPU(APU_NUSFLAGS_CPU),
       .DEBUG_TRIGGER_EN(DEBUG_TRIGGER_EN)
   ) id_stage_i (
-      .clk          (clk),  // Gated clock
+      .clk          (clk),    // Gated clock
       .clk_ungated_i(clk_i),  // Ungated clock
       .rst_n        (rst_ni),
 
@@ -592,14 +592,14 @@ module cv32e40p_core
       .regfile_alu_waddr_ex_o(regfile_alu_waddr_ex),
 
       // MUL
-      .mult_operator_ex_o   (mult_operator_ex),  // from ID to EX stage
-      .mult_en_ex_o         (mult_en_ex),  // from ID to EX stage
+      .mult_operator_ex_o   (mult_operator_ex),     // from ID to EX stage
+      .mult_en_ex_o         (mult_en_ex),           // from ID to EX stage
       .mult_sel_subword_ex_o(mult_sel_subword_ex),  // from ID to EX stage
       .mult_signed_mode_ex_o(mult_signed_mode_ex),  // from ID to EX stage
-      .mult_operand_a_ex_o  (mult_operand_a_ex),  // from ID to EX stage
-      .mult_operand_b_ex_o  (mult_operand_b_ex),  // from ID to EX stage
-      .mult_operand_c_ex_o  (mult_operand_c_ex),  // from ID to EX stage
-      .mult_imm_ex_o        (mult_imm_ex),  // from ID to EX stage
+      .mult_operand_a_ex_o  (mult_operand_a_ex),    // from ID to EX stage
+      .mult_operand_b_ex_o  (mult_operand_b_ex),    // from ID to EX stage
+      .mult_operand_c_ex_o  (mult_operand_c_ex),    // from ID to EX stage
+      .mult_imm_ex_o        (mult_imm_ex),          // from ID to EX stage
 
       .mult_dot_op_a_ex_o  (mult_dot_op_a_ex),  // from ID to EX stage
       .mult_dot_op_b_ex_o  (mult_dot_op_b_ex),  // from ID to EX stage
@@ -636,9 +636,9 @@ module cv32e40p_core
       .current_priv_lvl_i   (current_priv_lvl),
       .csr_irq_sec_o        (csr_irq_sec),
       .csr_cause_o          (csr_cause),
-      .csr_save_if_o        (csr_save_if),  // control signal to save pc
-      .csr_save_id_o        (csr_save_id),  // control signal to save pc
-      .csr_save_ex_o        (csr_save_ex),  // control signal to save pc
+      .csr_save_if_o        (csr_save_if),          // control signal to save pc
+      .csr_save_id_o        (csr_save_id),          // control signal to save pc
+      .csr_save_ex_o        (csr_save_ex),          // control signal to save pc
       .csr_restore_mret_id_o(csr_restore_mret_id),  // control signal to restore pc
       .csr_restore_uret_id_o(csr_restore_uret_id),  // control signal to restore pc
 
@@ -655,11 +655,11 @@ module cv32e40p_core
       .hwlp_target_o(hwlp_target),
 
       // LSU
-      .data_req_ex_o       (data_req_ex),  // to load store unit
-      .data_we_ex_o        (data_we_ex),  // to load store unit
+      .data_req_ex_o       (data_req_ex),         // to load store unit
+      .data_we_ex_o        (data_we_ex),          // to load store unit
       .atop_ex_o           (data_atop_ex),
-      .data_type_ex_o      (data_type_ex),  // to load store unit
-      .data_sign_ext_ex_o  (data_sign_ext_ex),  // to load store unit
+      .data_type_ex_o      (data_type_ex),        // to load store unit
+      .data_sign_ext_ex_o  (data_sign_ext_ex),    // to load store unit
       .data_reg_offset_ex_o(data_reg_offset_ex),  // to load store unit
       .data_load_event_ex_o(data_load_event_ex),  // to load store unit
 
@@ -748,34 +748,34 @@ module cv32e40p_core
 
       // Alu signals from ID stage
       .alu_en_i        (alu_en_ex),
-      .alu_operator_i  (alu_operator_ex),  // from ID/EX pipe registers
+      .alu_operator_i  (alu_operator_ex),   // from ID/EX pipe registers
       .alu_operand_a_i (alu_operand_a_ex),  // from ID/EX pipe registers
       .alu_operand_b_i (alu_operand_b_ex),  // from ID/EX pipe registers
       .alu_operand_c_i (alu_operand_c_ex),  // from ID/EX pipe registers
-      .bmask_a_i       (bmask_a_ex),  // from ID/EX pipe registers
-      .bmask_b_i       (bmask_b_ex),  // from ID/EX pipe registers
-      .imm_vec_ext_i   (imm_vec_ext_ex),  // from ID/EX pipe registers
-      .alu_vec_mode_i  (alu_vec_mode_ex),  // from ID/EX pipe registers
-      .alu_is_clpx_i   (alu_is_clpx_ex),  // from ID/EX pipe registers
+      .bmask_a_i       (bmask_a_ex),        // from ID/EX pipe registers
+      .bmask_b_i       (bmask_b_ex),        // from ID/EX pipe registers
+      .imm_vec_ext_i   (imm_vec_ext_ex),    // from ID/EX pipe registers
+      .alu_vec_mode_i  (alu_vec_mode_ex),   // from ID/EX pipe registers
+      .alu_is_clpx_i   (alu_is_clpx_ex),    // from ID/EX pipe registers
       .alu_is_subrot_i (alu_is_subrot_ex),  // from ID/Ex pipe registers
-      .alu_clpx_shift_i(alu_clpx_shift_ex),  // from ID/EX pipe registers
+      .alu_clpx_shift_i(alu_clpx_shift_ex), // from ID/EX pipe registers
 
       // Multipler
-      .mult_operator_i   (mult_operator_ex),  // from ID/EX pipe registers
-      .mult_operand_a_i  (mult_operand_a_ex),  // from ID/EX pipe registers
-      .mult_operand_b_i  (mult_operand_b_ex),  // from ID/EX pipe registers
-      .mult_operand_c_i  (mult_operand_c_ex),  // from ID/EX pipe registers
-      .mult_en_i         (mult_en_ex),  // from ID/EX pipe registers
+      .mult_operator_i   (mult_operator_ex),     // from ID/EX pipe registers
+      .mult_operand_a_i  (mult_operand_a_ex),    // from ID/EX pipe registers
+      .mult_operand_b_i  (mult_operand_b_ex),    // from ID/EX pipe registers
+      .mult_operand_c_i  (mult_operand_c_ex),    // from ID/EX pipe registers
+      .mult_en_i         (mult_en_ex),           // from ID/EX pipe registers
       .mult_sel_subword_i(mult_sel_subword_ex),  // from ID/EX pipe registers
       .mult_signed_mode_i(mult_signed_mode_ex),  // from ID/EX pipe registers
-      .mult_imm_i        (mult_imm_ex),  // from ID/EX pipe registers
-      .mult_dot_op_a_i   (mult_dot_op_a_ex),  // from ID/EX pipe registers
-      .mult_dot_op_b_i   (mult_dot_op_b_ex),  // from ID/EX pipe registers
-      .mult_dot_op_c_i   (mult_dot_op_c_ex),  // from ID/EX pipe registers
-      .mult_dot_signed_i (mult_dot_signed_ex),  // from ID/EX pipe registers
-      .mult_is_clpx_i    (mult_is_clpx_ex),  // from ID/EX pipe registers
-      .mult_clpx_shift_i (mult_clpx_shift_ex),  // from ID/EX pipe registers
-      .mult_clpx_img_i   (mult_clpx_img_ex),  // from ID/EX pipe registers
+      .mult_imm_i        (mult_imm_ex),          // from ID/EX pipe registers
+      .mult_dot_op_a_i   (mult_dot_op_a_ex),     // from ID/EX pipe registers
+      .mult_dot_op_b_i   (mult_dot_op_b_ex),     // from ID/EX pipe registers
+      .mult_dot_op_c_i   (mult_dot_op_c_ex),     // from ID/EX pipe registers
+      .mult_dot_signed_i (mult_dot_signed_ex),   // from ID/EX pipe registers
+      .mult_is_clpx_i    (mult_is_clpx_ex),      // from ID/EX pipe registers
+      .mult_clpx_shift_i (mult_clpx_shift_ex),   // from ID/EX pipe registers
+      .mult_clpx_img_i   (mult_clpx_img_ex),     // from ID/EX pipe registers
 
       .mult_multicycle_o(mult_multicycle),  // to ID/EX pipe registers
 
@@ -873,8 +873,8 @@ module cv32e40p_core
       .data_req_o    (data_req_pmp),
       .data_gnt_i    (data_gnt_pmp),
       .data_rvalid_i (data_rvalid_i),
-      .data_err_i    (1'b0),  // Bus error (not used yet)
-      .data_err_pmp_i(data_err_pmp),  // PMP error
+      .data_err_i    (1'b0),           // Bus error (not used yet)
+      .data_err_pmp_i(data_err_pmp),   // PMP error
 
       .data_addr_o (data_addr_pmp),
       .data_we_o   (data_we_o),
@@ -890,7 +890,7 @@ module cv32e40p_core
       .data_wdata_ex_i     (alu_operand_c_ex),
       .data_reg_offset_ex_i(data_reg_offset_ex),
       .data_load_event_ex_i(data_load_event_ex),
-      .data_sign_ext_ex_i  (data_sign_ext_ex),  // sign extension
+      .data_sign_ext_ex_i  (data_sign_ext_ex),    // sign extension
 
       .data_rdata_ex_o  (lsu_rdata),
       .data_req_ex_i    (data_req_ex),

--- a/rtl/cv32e40p_ex_stage.sv
+++ b/rtl/cv32e40p_ex_stage.sv
@@ -149,7 +149,7 @@ module cv32e40p_ex_stage
 
     output logic ex_ready_o,  // EX stage ready for new data
     output logic ex_valid_o,  // EX stage gets new data
-    input  logic wb_ready_i  // WB stage ready for new data
+    input  logic wb_ready_i   // WB stage ready for new data
 );
 
   logic [31:0] alu_result;

--- a/rtl/cv32e40p_fp_wrapper.sv
+++ b/rtl/cv32e40p_fp_wrapper.sv
@@ -63,32 +63,29 @@ module cv32e40p_fp_wrapper
   // -----------
   // Features (enabled formats, vectors etc.)
   localparam fpnew_pkg::fpu_features_t FPU_FEATURES = '{
-    Width:         C_FLEN,
-    EnableVectors: C_XFVEC,
-    EnableNanBox:  1'b0,
-    FpFmtMask: {
-    C_RVF, C_RVD, C_XF16, C_XF8, C_XF16ALT
-  }, IntFmtMask: {
-    C_XFVEC && C_XF8, C_XFVEC && (C_XF16 || C_XF16ALT), 1'b1, 1'b0
-  }};
+      Width: C_FLEN,
+      EnableVectors: C_XFVEC,
+      EnableNanBox: 1'b0,
+      FpFmtMask: {C_RVF, C_RVD, C_XF16, C_XF8, C_XF16ALT},
+      IntFmtMask: {C_XFVEC && C_XF8, C_XFVEC && (C_XF16 || C_XF16ALT), 1'b1, 1'b0}
+  };
 
   // Implementation (number of registers etc)
   localparam fpnew_pkg::fpu_implementation_t FPU_IMPLEMENTATION = '{
-  PipeRegs:  '{// FP32, FP64, FP16, FP8, FP16alt
-      '{
-          FPU_ADDMUL_LAT, C_LAT_FP64, C_LAT_FP16, C_LAT_FP8, C_LAT_FP16ALT
-      },  // ADDMUL
-      '{default: C_LAT_DIVSQRT},  // DIVSQRT
-      '{default: FPU_OTHERS_LAT},  // NONCOMP
-      '{default: FPU_OTHERS_LAT}
-  },  // CONV
-  UnitTypes: '{
-      '{default: fpnew_pkg::MERGED},  // ADDMUL
-      '{default: fpnew_pkg::MERGED},  // DIVSQRT
-      '{default: fpnew_pkg::PARALLEL},  // NONCOMP
-      '{default: fpnew_pkg::MERGED}
-  },  // CONV
-  PipeConfig: fpnew_pkg::AFTER};
+      PipeRegs: '{  // FP32, FP64, FP16, FP8, FP16alt
+          '{FPU_ADDMUL_LAT, C_LAT_FP64, C_LAT_FP16, C_LAT_FP8, C_LAT_FP16ALT},  // ADDMUL
+          '{default: C_LAT_DIVSQRT},  // DIVSQRT
+          '{default: FPU_OTHERS_LAT},  // NONCOMP
+          '{default: FPU_OTHERS_LAT}
+      },  // CONV
+      UnitTypes: '{
+          '{default: fpnew_pkg::MERGED},  // ADDMUL
+          '{default: fpnew_pkg::MERGED},  // DIVSQRT
+          '{default: fpnew_pkg::PARALLEL},  // NONCOMP
+          '{default: fpnew_pkg::MERGED}
+      },  // CONV
+      PipeConfig: fpnew_pkg::AFTER
+  };
 
   //---------------
   // FPU instance

--- a/rtl/cv32e40p_hwloop_regs.sv
+++ b/rtl/cv32e40p_hwloop_regs.sv
@@ -34,7 +34,7 @@ module cv32e40p_hwloop_regs #(
     input logic [          31:0] hwlp_end_data_i,
     input logic [          31:0] hwlp_cnt_data_i,
     input logic [           2:0] hwlp_we_i,
-    input logic [N_REG_BITS-1:0] hwlp_regid_i,  // selects the register set
+    input logic [N_REG_BITS-1:0] hwlp_regid_i,       // selects the register set
 
     // from controller
     input logic valid_i,

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -61,7 +61,7 @@ module cv32e40p_id_stage
 
     // Interface to IF stage
     input  logic        instr_valid_i,
-    input  logic [31:0] instr_rdata_i,  // comes from pipeline of IF stage
+    input  logic [31:0] instr_rdata_i,    // comes from pipeline of IF stage
     output logic        instr_req_o,
     input  logic        is_compressed_i,
     input  logic        illegal_c_insn_i,
@@ -196,8 +196,8 @@ module cv32e40p_id_stage
     // Interrupt signals
     input  logic [31:0] irq_i,
     input  logic        irq_sec_i,
-    input  logic [31:0] mie_bypass_i,  // MIE CSR (bypass)
-    output logic [31:0] mip_o,  // MIP CSR
+    input  logic [31:0] mie_bypass_i,    // MIE CSR (bypass)
+    output logic [31:0] mip_o,           // MIP CSR
     input  logic        m_irq_enable_i,
     input  logic        u_irq_enable_i,
     output logic        irq_ack_o,
@@ -1086,7 +1086,7 @@ module cv32e40p_id_stage
       .COREV_CLUSTER(COREV_CLUSTER),
       .COREV_PULP   (COREV_PULP)
   ) controller_i (
-      .clk          (clk),  // Gated clock
+      .clk          (clk),            // Gated clock
       .clk_ungated_i(clk_ungated_i),  // Ungated clock
       .rst_n        (rst_n),
 

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -80,7 +80,7 @@ module cv32e40p_if_stage #(
 
     input  logic [4:0] m_exc_vec_pc_mux_i,  // selects ISR address for vectorized interrupt lines
     input  logic [4:0] u_exc_vec_pc_mux_i,  // selects ISR address for vectorized interrupt lines
-    output logic       csr_mtvec_init_o,  // tell CS regfile to init mtvec
+    output logic       csr_mtvec_init_o,    // tell CS regfile to init mtvec
 
     // jump and branch target and decision
     input logic [31:0] jump_target_id_i,  // jump target address
@@ -95,7 +95,7 @@ module cv32e40p_if_stage #(
     input logic id_ready_i,
 
     // misc signals
-    output logic if_busy_o,  // is the IF stage busy fetching instructions?
+    output logic if_busy_o,    // is the IF stage busy fetching instructions?
     output logic perf_imiss_o  // Instruction Fetch Miss
 );
 
@@ -200,7 +200,7 @@ module cv32e40p_if_stage #(
       .instr_addr_o   (instr_addr_o),
       .instr_gnt_i    (instr_gnt_i),
       .instr_rvalid_i (instr_rvalid_i),
-      .instr_err_i    (instr_err_i),  // Not supported (yet)
+      .instr_err_i    (instr_err_i),      // Not supported (yet)
       .instr_err_pmp_i(instr_err_pmp_i),  // Not supported (yet)
       .instr_rdata_i  (instr_rdata_i),
 

--- a/rtl/cv32e40p_int_controller.sv
+++ b/rtl/cv32e40p_int_controller.sv
@@ -30,8 +30,8 @@ module cv32e40p_int_controller
     input logic rst_n,
 
     // External interrupt lines
-    input logic [31:0] irq_i,  // Level-triggered interrupt inputs
-    input logic        irq_sec_i,  // Interrupt secure bit from EU
+    input logic [31:0] irq_i,     // Level-triggered interrupt inputs
+    input logic        irq_sec_i, // Interrupt secure bit from EU
 
     // To cv32e40p_controller
     output logic       irq_req_ctrl_o,
@@ -40,10 +40,10 @@ module cv32e40p_int_controller
     output logic       irq_wu_ctrl_o,
 
     // To/from cv32e40p_cs_registers
-    input  logic     [31:0] mie_bypass_i,  // MIE CSR (bypass)
-    output logic     [31:0] mip_o,  // MIP CSR
-    input  logic            m_ie_i,  // Interrupt enable bit from CSR (M mode)
-    input  logic            u_ie_i,  // Interrupt enable bit from CSR (U mode)
+    input  logic     [31:0] mie_bypass_i,       // MIE CSR (bypass)
+    output logic     [31:0] mip_o,              // MIP CSR
+    input  logic            m_ie_i,             // Interrupt enable bit from CSR (M mode)
+    input  logic            u_ie_i,             // Interrupt enable bit from CSR (U mode)
     input  PrivLvl_t        current_priv_lvl_i
 );
 

--- a/rtl/cv32e40p_load_store_unit.sv
+++ b/rtl/cv32e40p_load_store_unit.sv
@@ -43,27 +43,27 @@ module cv32e40p_load_store_unit #(
     input  logic [31:0] data_rdata_i,
 
     // signals from ex stage
-    input logic        data_we_ex_i,  // write enable                      -> from ex stage
-    input logic [ 1:0] data_type_ex_i,  // Data type word, halfword, byte    -> from ex stage
-    input logic [31:0] data_wdata_ex_i,  // data to write to memory           -> from ex stage
+    input logic        data_we_ex_i,          // write enable                      -> from ex stage
+    input logic [ 1:0] data_type_ex_i,        // Data type word, halfword, byte    -> from ex stage
+    input logic [31:0] data_wdata_ex_i,       // data to write to memory           -> from ex stage
     input logic [ 1:0] data_reg_offset_ex_i,  // offset inside register for stores -> from ex stage
     input logic        data_load_event_ex_i,  // load event                        -> from ex stage
-    input logic [ 1:0] data_sign_ext_ex_i,  // sign extension                    -> from ex stage
+    input logic [ 1:0] data_sign_ext_ex_i,    // sign extension                    -> from ex stage
 
-    output logic [31:0] data_rdata_ex_o,  // requested data                    -> to ex stage
-    input  logic        data_req_ex_i,  // data request                      -> from ex stage
-    input  logic [31:0] operand_a_ex_i,  // operand a from RF for address     -> from ex stage
-    input  logic [31:0] operand_b_ex_i,  // operand b from RF for address     -> from ex stage
-    input  logic        addr_useincr_ex_i,  // use a + b or just a for address   -> from ex stage
+    output logic [31:0] data_rdata_ex_o,   // requested data                    -> to ex stage
+    input  logic        data_req_ex_i,     // data request                      -> from ex stage
+    input  logic [31:0] operand_a_ex_i,    // operand a from RF for address     -> from ex stage
+    input  logic [31:0] operand_b_ex_i,    // operand b from RF for address     -> from ex stage
+    input  logic        addr_useincr_ex_i, // use a + b or just a for address   -> from ex stage
 
-    input  logic data_misaligned_ex_i,  // misaligned access in last ld/st   -> from ID/EX pipeline
+    input logic data_misaligned_ex_i,  // misaligned access in last ld/st   -> from ID/EX pipeline
     output logic data_misaligned_o,  // misaligned access was detected    -> to controller
 
-    input  logic [5:0] data_atop_ex_i,  // atomic instructions signal        -> from ex stage
+    input logic [5:0] data_atop_ex_i,  // atomic instructions signal        -> from ex stage
     output logic [5:0] data_atop_o,  // atomic instruction signal         -> core output
 
     output logic p_elw_start_o,  // load event starts
-    output logic p_elw_finish_o,  // load event finishes
+    output logic p_elw_finish_o, // load event finishes
 
     // stall signal
     output logic lsu_ready_ex_o,  // LSU ready for new data in EX stage
@@ -468,7 +468,7 @@ module cv32e40p_load_store_unit #(
 
       .resp_valid_o(resp_valid),
       .resp_rdata_o(resp_rdata),
-      .resp_err_o  (resp_err),  // Unused for now
+      .resp_err_o  (resp_err),    // Unused for now
 
       .obi_req_o   (data_req_o),
       .obi_gnt_i   (data_gnt_i),
@@ -476,10 +476,10 @@ module cv32e40p_load_store_unit #(
       .obi_we_o    (data_we_o),
       .obi_be_o    (data_be_o),
       .obi_wdata_o (data_wdata_o),
-      .obi_atop_o  (data_atop_o),  // Not (yet) defined in OBI 1.0 spec
+      .obi_atop_o  (data_atop_o),    // Not (yet) defined in OBI 1.0 spec
       .obi_rdata_i (data_rdata_i),
       .obi_rvalid_i(data_rvalid_i),
-      .obi_err_i   (data_err_i)  // External bus error (validity defined by obi_rvalid_i)
+      .obi_err_i   (data_err_i)      // External bus error (validity defined by obi_rvalid_i)
   );
 
 

--- a/rtl/cv32e40p_mult.sv
+++ b/rtl/cv32e40p_mult.sv
@@ -370,9 +370,7 @@ module cv32e40p_mult
     |->
     (result_o == (($signed(
       {{32{op_a_i[31]}}, op_a_i}
-  ) * {
-    32'b0, op_b_i
-  }) >> 32)));
+  ) * {32'b0, op_b_i}) >> 32)));
 
   // check multiplication result for mulhu
   assert property (

--- a/rtl/cv32e40p_prefetch_buffer.sv
+++ b/rtl/cv32e40p_prefetch_buffer.sv
@@ -48,8 +48,8 @@ module cv32e40p_prefetch_buffer #(
     output logic [31:0] instr_addr_o,
     input  logic [31:0] instr_rdata_i,
     input  logic        instr_rvalid_i,
-    input  logic        instr_err_i,  // Not used yet (future addition)
-    input  logic        instr_err_pmp_i,  // Not used yet (future addition)
+    input  logic        instr_err_i,     // Not used yet (future addition)
+    input  logic        instr_err_pmp_i, // Not used yet (future addition)
 
     // Prefetch Buffer Status
     output logic busy_o
@@ -167,15 +167,15 @@ module cv32e40p_prefetch_buffer #(
 
       .resp_valid_o(resp_valid),
       .resp_rdata_o(resp_rdata),
-      .resp_err_o  (resp_err),  // Unused for now
+      .resp_err_o  (resp_err),    // Unused for now
 
       .obi_req_o   (instr_req_o),
       .obi_gnt_i   (instr_gnt_i),
       .obi_addr_o  (instr_addr_o),
-      .obi_we_o    (),  // Left unconnected on purpose
-      .obi_be_o    (),  // Left unconnected on purpose
-      .obi_wdata_o (),  // Left unconnected on purpose
-      .obi_atop_o  (),  // Left unconnected on purpose
+      .obi_we_o    (),                // Left unconnected on purpose
+      .obi_be_o    (),                // Left unconnected on purpose
+      .obi_wdata_o (),                // Left unconnected on purpose
+      .obi_atop_o  (),                // Left unconnected on purpose
       .obi_rdata_i (instr_rdata_i),
       .obi_rvalid_i(instr_rvalid_i),
       .obi_err_i   (instr_err_i)

--- a/rtl/cv32e40p_prefetch_controller.sv
+++ b/rtl/cv32e40p_prefetch_controller.sv
@@ -47,10 +47,10 @@ module cv32e40p_prefetch_controller #(
     input logic rst_n,
 
     // Fetch stage interface
-    input  logic        req_i,  // Fetch stage requests instructions
-    input  logic        branch_i,  // Taken branch
+    input  logic        req_i,          // Fetch stage requests instructions
+    input  logic        branch_i,       // Taken branch
     input  logic [31:0] branch_addr_i,  // Taken branch address (only valid when branch_i = 1)
-    output logic        busy_o,  // Prefetcher busy
+    output logic        busy_o,         // Prefetcher busy
 
     // HW loop signals
     input logic        hwlp_jump_i,

--- a/rtl/cv32e40p_sleep_unit.sv
+++ b/rtl/cv32e40p_sleep_unit.sv
@@ -59,8 +59,8 @@ module cv32e40p_sleep_unit #(
     // Clock, reset interface
     input  logic clk_ungated_i,  // Free running clock
     input  logic rst_n,
-    output logic clk_gated_o,  // Gated clock
-    input  logic scan_cg_en_i,  // Enable all clock gates for testing
+    output logic clk_gated_o,    // Gated clock
+    input  logic scan_cg_en_i,   // Enable all clock gates for testing
 
     // Core sleep
     output logic core_sleep_o,

--- a/rtl/cv32e40p_top.sv
+++ b/rtl/cv32e40p_top.sv
@@ -52,7 +52,7 @@ module cv32e40p_top #(
     input  logic [31:0] data_rdata_i,
 
     // Interrupt inputs
-    input  logic [31:0] irq_i,  // CLINT interrupts + CLINT extension interrupts
+    input  logic [31:0] irq_i,      // CLINT interrupts + CLINT extension interrupts
     output logic        irq_ack_o,
     output logic [ 4:0] irq_id_o,
 


### PR DESCRIPTION
This pull request add two 

- HW loop support on rvfi
- Improved floating point support. Instructions using the fpu are now issued to a dedicated fifo allowing standard instructions to be monitored at the same time.