### PR TITLE
RVFI - Urgent rvfi trap fix

### DIFF
--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -1194,40 +1194,40 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     bit s_is_pc_set;  //If pc_set, wait until next trace_id to commit csr changes
     bit s_is_irq_start;
 
-    bit s_skip_wb; // used to skip wb monitoring when apu resp and not lsu
+    bit s_skip_wb;  // used to skip wb monitoring when apu resp and not lsu
     bit s_increase_instret_1;
     bit s_increase_instret_2;
 
-    trace_if = new();
-    trace_id = new();
-    trace_ex = new();
-    trace_wb = new();
-    s_new_valid_insn = 1'b0;
-    s_ex_valid_adjusted = 1'b0;
+    trace_if             = new();
+    trace_id             = new();
+    trace_ex             = new();
+    trace_wb             = new();
+    s_new_valid_insn     = 1'b0;
+    s_ex_valid_adjusted  = 1'b0;
 
-    s_id_done = 1'b0;
-    s_apu_wb_ok = 1'b0;
-    s_apu_0_cycle_reps = 1'b0;
+    s_id_done            = 1'b0;
+    s_apu_wb_ok          = 1'b0;
+    s_apu_0_cycle_reps   = 1'b0;
 
-    next_send = 1;
-    cnt_data_req = 0;
-    cnt_data_resp = 0;
-    cnt_apu_req = 0;
-    cnt_apu_resp = 0;
-    csr_is_irq = '0;
-    is_dbg_taken = '0;
-    s_was_flush = 1'b0;
+    next_send            = 1;
+    cnt_data_req         = 0;
+    cnt_data_resp        = 0;
+    cnt_apu_req          = 0;
+    cnt_apu_resp         = 0;
+    csr_is_irq           = '0;
+    is_dbg_taken         = '0;
+    s_was_flush          = 1'b0;
 
-    r_previous_minstret = -1;
+    r_previous_minstret  = -1;
 
-    s_is_pc_set = 1'b0;
-    s_is_irq_start = 1'b0;
+    s_is_pc_set          = 1'b0;
+    s_is_irq_start       = 1'b0;
 
-    s_is_pc_set = 1'b0;
-    s_is_irq_start = 1'b0;
-    s_skip_wb      = 1'b0;
+    s_is_pc_set          = 1'b0;
+    s_is_irq_start       = 1'b0;
+    s_skip_wb            = 1'b0;
 
-    r_instret_cnt = 0;
+    r_instret_cnt        = 0;
     s_increase_instret_1 = 1'b0;
     s_increase_instret_2 = 1'b0;
 
@@ -1238,7 +1238,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
 
       check_trap();
 
-      if(s_increase_instret_2) begin
+      if (s_increase_instret_2) begin
         r_instret_cnt = r_instret_cnt + 1;
       end
       s_increase_instret_2 = s_increase_instret_1;
@@ -1334,11 +1334,11 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       s_skip_wb = 1'b0;
       if (r_pipe_freeze_trace.apu_rvalid && (apu_trace_q.size() > 0)) begin
         apu_resp();
-        if(!r_pipe_freeze_trace.data_rvalid) begin
+        if (!r_pipe_freeze_trace.data_rvalid) begin
           s_skip_wb = 1'b1;
         end
-      // end else if (r_pipe_freeze_trace.data_rvalid && (lsu_trace_q.size() > 0)) begin
-      //   lsu_resp();
+        // end else if (r_pipe_freeze_trace.data_rvalid && (lsu_trace_q.size() > 0)) begin
+        //   lsu_resp();
       end
       if (trace_wb.m_valid && !s_skip_wb) begin
         if (r_pipe_freeze_trace.rf_we_wb) begin

--- a/bhv/insn_trace.sv
+++ b/bhv/insn_trace.sv
@@ -54,6 +54,8 @@
 
     bit m_move_down_pipe;
 
+    int m_instret_cnt;
+
     struct {
       logic [31:0] addr ;
       logic [ 3:0] rmask;
@@ -146,6 +148,7 @@
       this.m_trap              = 1'b0;
       this.m_fflags_we_non_apu = 1'b0;
       this.m_frm_we_non_apu    = 1'b0;
+      this.m_instret_cnt       = 0;
     endfunction
 
     /*
@@ -174,6 +177,7 @@
       this.m_got_ex_reg        = 1'b0;
       this.m_got_regs_write    = 1'b0;
       this.m_move_down_pipe    = 1'b0;
+      this.m_instret_cnt       = 0;
       this.m_rd_addr[0]        = '0;
       this.m_rd_addr[1]        = '0;
       this.m_2_rd_insn         = 1'b0;
@@ -237,6 +241,7 @@
       this.m_is_ebreak          = m_source.m_is_ebreak;
       this.m_is_illegal         = m_source.m_is_illegal;
       this.m_is_irq             = m_source.m_is_irq;
+      this.m_instret_cnt        = m_source.m_instret_cnt;
       this.m_rs1_addr           = m_source.m_rs1_addr;
       this.m_rs2_addr           = m_source.m_rs2_addr;
       this.m_rs1_rdata          = m_source.m_rs1_rdata;


### PR DESCRIPTION
Previous PR based trap signaling on minstret csr. When this csr is inhibited, this cause rvfi to signal every instruction as trap, thus not creating any checks.
This PR fix this for most test.
There might still be some issue but to get everyone working I am issuing this PR anyway