### PR TITLE
[skip ci] Version 2 RTD configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Configuration file for ReadTheDocs, used to render the CV32E40P User Manual to
+# https://docs.openhwgroup.org/projects/cv32e40p-user-manual
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.1
+
+version: 2
+
+#build:
+#  os: "ubuntu-20.04"
+#  tools:
+#    python: "3.9"
+
+# Build from the docs/source directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Explicitly set the Python requirements
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
As per email from RTD: The Read the Docs build system will start requiring a configuration file v2 (.readthedocs.yaml) starting on September 25, 2023.

Notes:
- This pull-request has no impact on v2 vs. v1 logical equivalence of the RTL, so the CI is skipped.
- This PR is the same as #825, this time for the `dev` branch (which is the branch currently used by RTD to render the User Manual).