### PR TITLE
[Skip CI] Added html, pdf and epub downloadable packages generation.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,11 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
 
+formats:
+  - htmlzip
+  - pdf
+  - epub
+
 # Explicitly set the Python requirements
 python:
   install:


### PR DESCRIPTION
Configuration done in .readthedocs.yaml was only generating on-line html but no any other packages.