### PR TITLE
RVFI updates for pulp post increment load instr, all CSR updates for FPU instructions and some general improvements

### DIFF
--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -135,6 +135,7 @@ module cv32e40p_rvfi
     input logic        rf_we_wb_i,
     input logic [ 5:0] rf_addr_wb_i,
     input logic [31:0] rf_wdata_wb_i,
+    input logic        regfile_alu_we_ex_i,
     // LSU
     input logic [31:0] lsu_rdata_wb_i,
 

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -642,6 +642,7 @@ module cv32e40p_rvfi
         end
       end
     end
+    trace_q_size = wb_bypass_trace_q.size();  //Re-calculate here for accurate status
   endfunction
   /*
    * Function used to alocate a new insn and send it to the rvfi driver
@@ -1403,6 +1404,7 @@ module cv32e40p_rvfi
         mtvec_to_id();
 
         `CSR_FROM_PIPE(id, mip)
+        `CSR_FROM_PIPE(id, misa)
 
         if (!csr_is_irq && !s_is_irq_start) begin
           mstatus_to_id();

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -1362,7 +1362,9 @@ module cv32e40p_rvfi
 
       if (trace_ex.m_valid) begin
 
-        minstret_to_ex();
+        if (!trace_ex.m_csr.got_minstret) begin
+          minstret_to_ex();
+        end
         `CSR_FROM_PIPE(ex, misa)
         `CSR_FROM_PIPE(ex, tdata1)
         tinfo_to_ex();
@@ -1406,7 +1408,9 @@ module cv32e40p_rvfi
               ->e_ex_to_wb_1;
               trace_wb.move_down_pipe(trace_ex);
             end else begin
-              minstret_to_ex();
+              if (!trace_ex.m_csr.got_minstret) begin
+                minstret_to_ex();
+              end
               send_rvfi(trace_ex);
             end
             trace_ex.m_valid = 1'b0;
@@ -1548,7 +1552,9 @@ module cv32e40p_rvfi
       if (s_new_valid_insn) begin  // There is a new valid instruction
         if (trace_id.m_valid) begin
           if (trace_ex.m_valid) begin
-            minstret_to_ex();
+            if (!trace_ex.m_csr.got_minstret) begin
+              minstret_to_ex();
+            end
             if (trace_wb.m_valid) begin
               send_rvfi(trace_ex);
               ->e_send_rvfi_trace_ex_4;

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -1372,8 +1372,13 @@ module cv32e40p_rvfi
             if (!s_ex_valid_adjusted & !trace_ex.m_csr.got_minstret) begin
               minstret_to_ex();
             end
-            ->e_ex_to_wb_1;
-            trace_wb.move_down_pipe(trace_ex);
+            if (trace_ex.m_is_load) begin  // only move relevant instr in wb stage
+              ->e_ex_to_wb_1;
+              trace_wb.move_down_pipe(trace_ex);
+            end else begin
+              minstret_to_ex();
+              send_rvfi(trace_ex);
+            end
             trace_ex.m_valid = 1'b0;
           end
         end else if (r_pipe_freeze_trace.rf_we_wb) begin
@@ -1512,8 +1517,13 @@ module cv32e40p_rvfi
               send_rvfi(trace_ex);
               ->e_send_rvfi_trace_ex_4;
             end else begin
-              ->e_ex_to_wb_2;
-              trace_wb.move_down_pipe(trace_ex);
+              if (trace_ex.m_is_load) begin // only move relevant instr in wb stage
+                ->e_ex_to_wb_2;
+                trace_wb.move_down_pipe(trace_ex);
+              end
+              else begin
+                send_rvfi(trace_ex);
+              end
             end
             trace_ex.m_valid = 1'b0;
           end

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -692,6 +692,7 @@ module cv32e40p_rvfi
   logic [31:0] s_fflags_mirror;
   logic [31:0] s_frm_mirror;
   logic [31:0] s_fcsr_mirror;
+  logic [31:0] s_mstatus_sd_fs_mirror;
 
   function void set_rvfi();
     insn_trace_t new_rvfi_trace;
@@ -713,11 +714,21 @@ module cv32e40p_rvfi
       end else begin
         s_fcsr_mirror = new_rvfi_trace.m_csr.fcsr_rdata;
       end
+      if (new_rvfi_trace.m_csr.mstatus_we) begin
+        s_mstatus_sd_fs_mirror = new_rvfi_trace.m_csr.mstatus_wdata & 32'h8000_6000;
+      end else begin
+        s_mstatus_sd_fs_mirror = new_rvfi_trace.m_csr.mstatus_rdata & 32'h8000_6000;
+      end
 
     end else begin
       new_rvfi_trace.m_csr.fflags_rdata = s_fflags_mirror;
       new_rvfi_trace.m_csr.frm_rdata = s_frm_mirror;
       new_rvfi_trace.m_csr.fcsr_rdata = s_fcsr_mirror;
+      if (s_mstatus_sd_fs_mirror != 32'h0) begin
+        new_rvfi_trace.m_csr.mstatus_wdata = new_rvfi_trace.m_csr.mstatus_wdata | s_mstatus_sd_fs_mirror;
+        new_rvfi_trace.m_csr.mstatus_wmask = 32'hFFFF_FFFF;
+        s_mstatus_sd_fs_mirror = 32'h0;  // Reset mirror
+      end
       if (new_rvfi_trace.m_fflags_we_non_apu) begin
         s_fflags_mirror = new_rvfi_trace.m_csr.fflags_wdata;
         s_fcsr_mirror = new_rvfi_trace.m_csr.fcsr_wdata;

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -339,6 +339,7 @@ module cv32e40p_tb_wrapper
       .rf_we_wb_i(cv32e40p_top_i.core_i.id_stage_i.regfile_we_wb_i),
       .rf_addr_wb_i(cv32e40p_top_i.core_i.id_stage_i.regfile_waddr_wb_i),
       .rf_wdata_wb_i(cv32e40p_top_i.core_i.id_stage_i.regfile_wdata_wb_i),
+      .regfile_alu_we_ex_i(cv32e40p_top_i.core_i.id_stage_i.regfile_alu_we_ex_o),
 
       // APU
       .apu_req_i   (cv32e40p_top_i.core_i.apu_req_o),

--- a/bhv/insn_trace.sv
+++ b/bhv/insn_trace.sv
@@ -38,6 +38,7 @@
 
     logic       m_fflags_we_non_apu;
     logic       m_frm_we_non_apu;
+    logic       m_fcsr_we_non_apu;
     logic [5:0] m_rs1_addr;
     logic [5:0] m_rs2_addr;
     logic [31:0] m_rs1_rdata;
@@ -148,6 +149,7 @@
       this.m_trap              = 1'b0;
       this.m_fflags_we_non_apu = 1'b0;
       this.m_frm_we_non_apu    = 1'b0;
+      this.m_fcsr_we_non_apu   = 1'b0;
       this.m_instret_cnt       = 0;
     endfunction
 
@@ -189,6 +191,7 @@
       this.m_trap              = 1'b0;
       this.m_fflags_we_non_apu = 1'b0;
       this.m_frm_we_non_apu    = 1'b0;
+      this.m_fcsr_we_non_apu   = 1'b0;
       this.m_csr.mcause_we = '0;
       if (is_compressed_id_i) begin
         this.m_insn[31:16] = '0;
@@ -256,6 +259,7 @@
       this.m_trap               = m_source.m_trap;
       this.m_fflags_we_non_apu  = m_source.m_fflags_we_non_apu;
       this.m_frm_we_non_apu     = m_source.m_frm_we_non_apu   ;
+      this.m_fcsr_we_non_apu    = m_source.m_fcsr_we_non_apu;
 
       this.m_mem                = m_source.m_mem;
       //CRS

--- a/bhv/insn_trace.sv
+++ b/bhv/insn_trace.sv
@@ -15,6 +15,10 @@
     this.m_csr.``CSR_NAME``_wdata = m_source.m_csr.``CSR_NAME``_wdata; \
     this.m_csr.``CSR_NAME``_wmask = m_source.m_csr.``CSR_NAME``_wmask;
 
+  `define INIT_CSR(CSR_NAME) \
+    this.m_csr.``CSR_NAME``_we    = '0; \
+    this.m_csr.``CSR_NAME``_wmask = '0;
+
   class insn_trace_t;
     bit m_valid;
     logic [63:0] m_order;
@@ -153,6 +157,36 @@
       this.m_instret_cnt       = 0;
     endfunction
 
+    function void init_csr();
+      `INIT_CSR(mstatus)
+      `INIT_CSR(misa)
+      `INIT_CSR(mie)
+      `INIT_CSR(mtvec)
+      `INIT_CSR(mcountinhibit)
+      `INIT_CSR(mscratch)
+      `INIT_CSR(mepc)
+      `INIT_CSR(mcause)
+      `INIT_CSR(minstret)
+      `INIT_CSR(mip)
+      `INIT_CSR(tdata1)
+      `INIT_CSR(tdata2)
+      `INIT_CSR(tinfo)
+      `INIT_CSR(dcsr)
+      `INIT_CSR(dpc)
+      `INIT_CSR(dscratch0)
+      `INIT_CSR(dscratch1)
+      `INIT_CSR(mvendorid)
+      `INIT_CSR(marchid)
+      `INIT_CSR(fflags)
+      `INIT_CSR(frm   )
+      `INIT_CSR(fcsr  )
+      `INIT_CSR(lpstart0 )
+      `INIT_CSR(lpend0   )
+      `INIT_CSR(lpcount0 )
+      `INIT_CSR(lpstart1 )
+      `INIT_CSR(lpend1   )
+      `INIT_CSR(lpcount1 )
+    endfunction
     /*
      *
      */
@@ -216,6 +250,8 @@
       this.m_mem.wmask   = '0;
       this.m_mem.rdata   = '0;
       this.m_mem.wdata   = '0;
+
+      init_csr();
     endfunction
 
     function logic [63:0] get_order_for_trap();

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -681,11 +681,11 @@ task monitor_pipeline();
 
     //If fcsr_we has triggered, then fflags_we and frm_we should also be triggered
     if (r_pipe_freeze_trace.csr.fcsr_we) begin
-      r_pipe_freeze_trace.csr.fflags_we  = 1'b1;
-      r_pipe_freeze_trace.csr.frm_we     = 1'b1;
+      r_pipe_freeze_trace.csr.fflags_we = 1'b1;
+      r_pipe_freeze_trace.csr.frm_we    = 1'b1;
     end else begin
       if (r_pipe_freeze_trace.csr.fflags_we || r_pipe_freeze_trace.csr.frm_we) begin
-        r_pipe_freeze_trace.csr.fcsr_we    = 1'b1;
+        r_pipe_freeze_trace.csr.fcsr_we = 1'b1;
       end
     end
 

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -678,6 +678,17 @@ task monitor_pipeline();
     r_pipe_freeze_trace.hwloop.counter_n = hwlp_counter_n_i;
 
     compute_csr_we();
+
+    //If fcsr_we has triggered, then fflags_we and frm_we should also be triggered
+    if (r_pipe_freeze_trace.csr.fcsr_we) begin
+      r_pipe_freeze_trace.csr.fflags_we  = 1'b1;
+      r_pipe_freeze_trace.csr.frm_we     = 1'b1;
+    end else begin
+      if (r_pipe_freeze_trace.csr.fflags_we || r_pipe_freeze_trace.csr.frm_we) begin
+        r_pipe_freeze_trace.csr.fcsr_we    = 1'b1;
+      end
+    end
+
     if (csr_fcsr_fflags_we_i) begin
       r_pipe_freeze_trace.csr.fflags_we  = 1'b1;
       r_pipe_freeze_trace.csr.fcsr_we    = 1'b1;

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -121,6 +121,7 @@ typedef struct {
   logic rf_we_wb;
   logic [5:0] rf_addr_wb;
   logic [31:0] rf_wdata_wb;
+  logic rf_alu_we_ex;
   // LSU
   logic [31:0] lsu_rdata_wb;
 
@@ -463,6 +464,7 @@ task monitor_pipeline();
     r_pipe_freeze_trace.rf_we_wb              = rf_we_wb_i;
     r_pipe_freeze_trace.rf_addr_wb            = rf_addr_wb_i;
     r_pipe_freeze_trace.rf_wdata_wb           = rf_wdata_wb_i;
+    r_pipe_freeze_trace.rf_alu_we_ex          = regfile_alu_we_ex_i;
     // LSU
     r_pipe_freeze_trace.lsu_rdata_wb          = lsu_rdata_wb_i;
 


### PR DESCRIPTION
This PR is for updaing RVFI for issues seen during simulations

1.  Fix for post-increment loads - use trace * m_rd_addr[0], m_rd_wdata[0] ,i.e, index 0 for any reg file updates from ALU for instructions with multiple register updates such as post increment loads.
2. Clean trace_wb to only move load instructions to this wb trace structure.
3. Fix FCSR updates to ensure this register update are captured for both APU instructions and explicit CSR updates. And also update fflags and frm CSRs accordingly.
4. Add logic to check for mstatus FS and SD fields update from FPU instructions.
5. Add INIT_CSR macro and corresponding function init_csr() for insn_trace to ensure each new object has a clean CSR values. Thus to ensure clean CSR update status for each instruction and also simplify debugging for CSR update issues for RVFI and reference model.
6. Check got_mistret flag is set or not before updating mistret csr from EX stage to avoid multiple updates to the CSR from ID and EX stage.