### PR TITLE
Better mstatus when FPU instruction

### DIFF
--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -1112,8 +1112,8 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     trace_apu_resp.m_csr.mstatus_wdata = r_pipe_freeze_trace.csr.mstatus_full_n;
     trace_apu_resp.m_csr.mstatus_wmask = r_pipe_freeze_trace.csr.mstatus_we ? '1 : '0;
 
-    if(r_pipe_freeze_trace.csr.mstatus_we) begin
-        trace_ex.m_csr.mstatus_rdata = r_pipe_freeze_trace.csr.mstatus_full_n;
+    if (r_pipe_freeze_trace.csr.mstatus_we) begin
+      trace_ex.m_csr.mstatus_rdata = r_pipe_freeze_trace.csr.mstatus_full_n;
     end
   endfunction
 

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -674,7 +674,6 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   logic [31:0] s_fflags_mirror;
   logic [31:0] s_frm_mirror;
   logic [31:0] s_fcsr_mirror;
-  logic [31:0] s_mstatus_sd_fs_mirror;
 
   function void set_rvfi();
     insn_trace_t new_rvfi_trace;
@@ -696,21 +695,12 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       end else begin
         s_fcsr_mirror = new_rvfi_trace.m_csr.fcsr_rdata;
       end
-      if (new_rvfi_trace.m_csr.mstatus_we) begin
-        s_mstatus_sd_fs_mirror = new_rvfi_trace.m_csr.mstatus_wdata & 32'h8000_6000;
-      end else begin
-        s_mstatus_sd_fs_mirror = new_rvfi_trace.m_csr.mstatus_rdata & 32'h8000_6000;
-      end
 
     end else begin
       new_rvfi_trace.m_csr.fflags_rdata = s_fflags_mirror;
       new_rvfi_trace.m_csr.frm_rdata = s_frm_mirror;
       new_rvfi_trace.m_csr.fcsr_rdata = s_fcsr_mirror;
-      // if (s_mstatus_sd_fs_mirror != 32'h0) begin
-      //   new_rvfi_trace.m_csr.mstatus_wdata = new_rvfi_trace.m_csr.mstatus_wdata | s_mstatus_sd_fs_mirror;
-      //   new_rvfi_trace.m_csr.mstatus_wmask = 32'hFFFF_FFFF;
-      //   s_mstatus_sd_fs_mirror = 32'h0;  // Reset mirror
-      // end
+
       if (new_rvfi_trace.m_fflags_we_non_apu) begin
         s_fflags_mirror = new_rvfi_trace.m_csr.fflags_wdata;
         s_fcsr_mirror = new_rvfi_trace.m_csr.fcsr_wdata;


### PR DESCRIPTION
When a floating point instruction cause an update of the mstatus csr, this update was not visble on the rvfi trace for non fpu instruction that were completed before the fpu response but are considered retired after.

This workaround updates the mstatus read value for all instructions that are completed before the fpu response but come latter in retire order