### PR TITLE
RVFI - Improving mstatsu_fs reporting and fcsr reporting

### DIFF
--- a/bhv/cv32e40p_instr_trace.svh
+++ b/bhv/cv32e40p_instr_trace.svh
@@ -679,22 +679,22 @@ class instr_trace_t;
       // decode and print instruction
       case (instr[11:8])
         // cv.starti, cv.endi
-        4'b0000, 4'b0010: str = $sformatf("%-16s %d, 0x%0x", mnemonic, rd[0], imm_iz_type);
+        4'b0000, 4'b0010: str = $sformatf("%-16s %d, 0x%0x", mnemonic, instr[7], imm_iz_type);
         // cv.counti
-        4'b0100: str = $sformatf("%-16s %d, %d", mnemonic, rd[0], imm_iz_type);
+        4'b0100: str = $sformatf("%-16s %d, %d", mnemonic, instr[7], imm_iz_type);
         // cv.start, cv.end, cv.count
         4'b0001, 4'b0011, 4'b0101: begin
           regs_read.push_back('{rs1, rs1_value, 0});
-          str = $sformatf("%-16s %d, %s", mnemonic, rd[0], regAddrToStr(rs1));
+          str = $sformatf("%-16s %d, %s", mnemonic, instr[7], regAddrToStr(rs1));
         end
         // cv.setupi
         4'b0110: begin
-          str = $sformatf("%-16s %d, %d, 0x%0x", mnemonic, rd[0], imm_iz_type, rs1);
+          str = $sformatf("%-16s %d, %d, 0x%0x", mnemonic, instr[7], imm_iz_type, rs1);
         end
         // cv.setup
         4'b0111: begin
           regs_read.push_back('{rs1, rs1_value, 0});
-          str = $sformatf("%-16s %d, %s, 0x%0x", mnemonic, rd[0], regAddrToStr(rs1), imm_iz_type);
+          str = $sformatf("%-16s %d, %s, 0x%0x", mnemonic, instr[7], regAddrToStr(rs1), imm_iz_type);
         end
       endcase
     end
@@ -861,7 +861,7 @@ class instr_trace_t;
           endcase
           str_sci  = "";
         end
-  
+
         // shuffle/pack
         6'b110000: begin
           if (instr[14:12] == 3'b111) begin

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -633,6 +633,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   logic   [2:0] saved_debug_cause;
   integer       next_send;
 
+  event e_empty_queue;
   function void empty_fifo();
     integer i, trace_q_size;
     trace_q_size = wb_bypass_trace_q.size();
@@ -648,6 +649,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
           new_rvfi_trace.m_csr.mstatus_fs_rdata = r_pipe_freeze_trace.csr.mstatus_fs_n;
           rvfi_trace_q.push_back(new_rvfi_trace);
           next_send = next_send + 1;
+          ->e_empty_queue;
         end else begin
           wb_bypass_trace_q.push_back(new_rvfi_trace);
         end
@@ -658,6 +660,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   /*
    * Function used to alocate a new insn and send it to the rvfi driver
    */
+   event e_add_to_bypass;
   function void send_rvfi(insn_trace_t m_wb_insn);
     insn_trace_t new_rvfi_trace;
     new_rvfi_trace = new();
@@ -667,6 +670,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       next_send = next_send + 1;
     end else begin
       wb_bypass_trace_q.push_back(new_rvfi_trace);
+      ->e_add_to_bypass;
     end
     empty_fifo();
   endfunction
@@ -1163,7 +1167,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     // `CSR_FROM_PIPE(apu_resp, mstatus)
     `CSR_FROM_PIPE(apu_resp, mstatus_fs)
 
-    if (r_pipe_freeze_trace.csr.mstatus_we) begin
+    if (r_pipe_freeze_trace.csr.mstatus_fs_we) begin
       trace_ex.m_csr.mstatus_fs_rdata = r_pipe_freeze_trace.csr.mstatus_fs_n;
     end
   endfunction

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -1115,6 +1115,9 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
    * The third updates the rvfi interface
    */
   `define CSR_FROM_PIPE(TRACE_NAME, CSR_NAME) \
+    if(!trace_``TRACE_NAME``.m_csr.``CSR_NAME``_we) begin \
+      trace_``TRACE_NAME``.m_csr.``CSR_NAME``_wdata   = r_pipe_freeze_trace.csr.``CSR_NAME``_n; \
+    end\
     if (r_pipe_freeze_trace.csr.``CSR_NAME``_we) begin \
       trace_``TRACE_NAME``.m_csr.``CSR_NAME``_we      = r_pipe_freeze_trace.csr.``CSR_NAME``_we; \
       trace_``TRACE_NAME``.m_csr.``CSR_NAME``_wdata   = r_pipe_freeze_trace.csr.``CSR_NAME``_n; \
@@ -1164,7 +1167,6 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     `CSR_FROM_PIPE(apu_resp, fcsr)
     `CSR_FROM_PIPE(apu_resp, fflags)
 
-    // `CSR_FROM_PIPE(apu_resp, mstatus)
     `CSR_FROM_PIPE(apu_resp, mstatus_fs)
 
     if (r_pipe_freeze_trace.csr.mstatus_fs_we) begin

--- a/bhv/include/cv32e40p_tracer_pkg.sv
+++ b/bhv/include/cv32e40p_tracer_pkg.sv
@@ -449,8 +449,8 @@ package cv32e40p_tracer_pkg;
   parameter INSTR_CVSHUFFLE2H = {5'b11100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
   parameter INSTR_CVSHUFFLE2B = {5'b11100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
 
-  parameter INSTR_CVPACK = {5'b11101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
-  parameter INSTR_CVPACKH = {5'b11101, 1'b0, 1'b1, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+  parameter INSTR_CVPACK = {5'b11110, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+  parameter INSTR_CVPACKH = {5'b11110, 1'b0, 1'b1, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
 
   parameter INSTR_CVPACKHIB = {5'b11111, 1'b0, 1'b1, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
   parameter INSTR_CVPACKLOB = {5'b11111, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -650,10 +650,6 @@ task monitor_pipeline();
     if (r_pipe_freeze_trace.csr.fcsr_we) begin
       r_pipe_freeze_trace.csr.fflags_we = 1'b1;
       r_pipe_freeze_trace.csr.frm_we    = 1'b1;
-    end else begin
-      if (r_pipe_freeze_trace.csr.fflags_we || r_pipe_freeze_trace.csr.frm_we) begin
-        r_pipe_freeze_trace.csr.fcsr_we = 1'b1;
-      end
     end
 
     if (csr_fcsr_fflags_we_i) begin


### PR DESCRIPTION
This PR corrects two points I previously overlooked

- moved the mstatus_fs reporting trigger for mstatus_we to mstatus_fs_we on APU instructions
- remove the fcsr_we when we have frm_we or fflags_we and use the already in place mechanism when populating rvfi signals to handle the multi csr update