### PR TITLE
RVFI - Better load results sampling when debug + csr sampling improvement

### DIFF
--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -1427,7 +1427,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
 
       s_new_valid_insn = r_pipe_freeze_trace.id_valid && r_pipe_freeze_trace.is_decoding;// && !r_pipe_freeze_trace.apu_rvalid;
 
-      s_wb_valid_adjusted = r_pipe_freeze_trace.wb_valid && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == FLUSH_EX) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_FLUSH) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_ID));// && !r_pipe_freeze_trace.apu_rvalid;;
+      s_wb_valid_adjusted = r_pipe_freeze_trace.wb_valid && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == FLUSH_EX) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_FLUSH) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_ID) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF));// && !r_pipe_freeze_trace.apu_rvalid;;
       s_ex_reg_we_adjusted = r_pipe_freeze_trace.ex_reg_we && r_pipe_freeze_trace.mult_ready && r_pipe_freeze_trace.alu_ready && r_pipe_freeze_trace.lsu_ready_ex && !s_apu_to_alu_port;
       s_rf_we_wb_adjusted = r_pipe_freeze_trace.rf_we_wb && (~r_pipe_freeze_trace.data_misaligned_ex && r_pipe_freeze_trace.wb_ready) && (!s_apu_to_lsu_port || r_pipe_freeze_trace.wb_contention_lsu);
 
@@ -1579,8 +1579,13 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
           end
         end
       end
+      //old
+      // s_ex_valid_adjusted = (r_pipe_freeze_trace.ex_valid && r_pipe_freeze_trace.ex_ready) && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF)) && (!r_pipe_freeze_trace.apu_rvalid || r_pipe_freeze_trace.data_req_ex);
+      //issue 51
+      s_ex_valid_adjusted = (r_pipe_freeze_trace.ex_valid && r_pipe_freeze_trace.ex_ready) && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF)  || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_FLUSH)) && (!r_pipe_freeze_trace.apu_rvalid || r_pipe_freeze_trace.data_req_ex);
 
-      s_ex_valid_adjusted = (r_pipe_freeze_trace.ex_valid && r_pipe_freeze_trace.ex_ready) && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF)) && (!r_pipe_freeze_trace.apu_rvalid || r_pipe_freeze_trace.data_req_ex);
+      // issue 49
+      // s_ex_valid_adjusted = (r_pipe_freeze_trace.ex_valid && r_pipe_freeze_trace.ex_ready) && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF) || (r_pipe_freeze_trace.ctrl_fsm_cs == FLUSH_EX)) && (!r_pipe_freeze_trace.apu_rvalid || r_pipe_freeze_trace.data_req_ex);
       //EX_STAGE
       if (trace_id.m_valid) begin
 

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -280,8 +280,11 @@ module cv32e40p_tb_wrapper
       .is_compressed_id_i(cv32e40p_top_i.core_i.id_stage_i.is_compressed_i),
       .ebrk_insn_dec_i   (cv32e40p_top_i.core_i.id_stage_i.ebrk_insn_dec),
       .ecall_insn_dec_i  (cv32e40p_top_i.core_i.id_stage_i.ecall_insn_dec),
-      .csr_cause_i       (cv32e40p_top_i.core_i.csr_cause),
-      .debug_csr_save_i  (cv32e40p_top_i.core_i.debug_csr_save),
+      .mret_insn_dec_i   (cv32e40p_top_i.core_i.id_stage_i.mret_insn_dec),
+      .mret_dec_i        (cv32e40p_top_i.core_i.id_stage_i.mret_dec),
+
+      .csr_cause_i     (cv32e40p_top_i.core_i.csr_cause),
+      .debug_csr_save_i(cv32e40p_top_i.core_i.debug_csr_save),
 
       // HWLOOP regs
       .hwlp_start_q_i  (hwlp_start_q),

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -65,6 +65,8 @@ typedef struct {
 
   logic ebrk_insn_dec;
   logic ecall_insn_dec;
+  logic mret_insn_dec;
+  logic mret_dec;
 
   logic [5:0] csr_cause;
 
@@ -354,19 +356,21 @@ function compute_csr_we();
         r_pipe_freeze_trace.csr.mstatus_we    = 1'b1;
         r_pipe_freeze_trace.csr.mstatus_fs_we = 1'b1;
       end
-      CSR_MISA:     r_pipe_freeze_trace.csr.misa_we = 1'b1;
-      CSR_MTVEC:    r_pipe_freeze_trace.csr.mtvec_we = 1'b1;
-      CSR_MSCRATCH: r_pipe_freeze_trace.csr.mscratch_we = 1'b1;
-      CSR_MEPC:     r_pipe_freeze_trace.csr.mepc_we = 1'b1;
-      CSR_MCAUSE:   r_pipe_freeze_trace.csr.mcause_we = 1'b1;
-      CSR_DCSR:     r_pipe_freeze_trace.csr.dcsr_we = 1'b1;
+      CSR_MISA:      r_pipe_freeze_trace.csr.misa_we = 1'b1;
+      CSR_MTVEC:     r_pipe_freeze_trace.csr.mtvec_we = 1'b1;
+      CSR_MSCRATCH:  r_pipe_freeze_trace.csr.mscratch_we = 1'b1;
+      CSR_MEPC:      r_pipe_freeze_trace.csr.mepc_we = 1'b1;
+      CSR_MCAUSE:    r_pipe_freeze_trace.csr.mcause_we = 1'b1;
+      CSR_DCSR:      r_pipe_freeze_trace.csr.dcsr_we = 1'b1;
       CSR_FFLAGS: begin
         r_pipe_freeze_trace.csr.fflags_we = 1'b1;
         r_pipe_freeze_trace.csr.mstatus_fs_we = 1'b1;
       end
-      CSR_FRM:      r_pipe_freeze_trace.csr.frm_we = 1'b1;
-      CSR_FCSR:     r_pipe_freeze_trace.csr.fcsr_we = 1'b1;
-      CSR_DPC:      r_pipe_freeze_trace.csr.dpc_we = 1'b1;
+      CSR_FRM:       r_pipe_freeze_trace.csr.frm_we = 1'b1;
+      CSR_FCSR:      r_pipe_freeze_trace.csr.fcsr_we = 1'b1;
+      CSR_DPC:       r_pipe_freeze_trace.csr.dpc_we = 1'b1;
+      CSR_DSCRATCH0: r_pipe_freeze_trace.csr.dscratch0_we = 1'b1;
+      CSR_DSCRATCH1: r_pipe_freeze_trace.csr.dscratch1_we = 1'b1;
     endcase
   end
   // CSR_MCAUSE:   r_pipe_freeze_trace.csr.mcause_we = r_pipe_freeze_trace.csr.mcause_n != r_pipe_freeze_trace.csr.mcause_q; //for debug purpose
@@ -426,6 +430,8 @@ task monitor_pipeline();
     r_pipe_freeze_trace.is_compressed_id = is_compressed_id_i;
     r_pipe_freeze_trace.ebrk_insn_dec = ebrk_insn_dec_i;
     r_pipe_freeze_trace.ecall_insn_dec = ecall_insn_dec_i;
+    r_pipe_freeze_trace.mret_insn_dec = mret_insn_dec_i;
+    r_pipe_freeze_trace.mret_dec = mret_dec_i;
     r_pipe_freeze_trace.csr_cause = csr_cause_i;
     r_pipe_freeze_trace.debug_csr_save = debug_csr_save_i;
     r_pipe_freeze_trace.minstret = minstret_i;


### PR DESCRIPTION
This PR corrects few corner cases:

- load instruction followed by debug request
- csr write to dscratch
- mstatus update caused by mret