### PR TITLE
Aligned all RTL/BHV files headers with correct date, contributors and Solderpad Hardware License v2.1

### DIFF
--- a/bhv/cv32e40p_apu_tracer.sv
+++ b/bhv/cv32e40p_apu_tracer.sv
@@ -1,38 +1,27 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2020 Silicon Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// This file, and derivatives thereof are licensed under the
-// Solderpad License, Version 2.0 (the "License").
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
 //
-// Use of this file means you agree to the terms and conditions
-// of the license and are in full compliance with the License.
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// You may obtain a copy of the License at:
-//
-//     https://solderpad.org/licenses/SHL-2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// and hardware implementations thereof distributed under the License
-// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
-//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
-//                                                                            //
-// Design Name:    cv32e40p_apu_tracer.sv (APU trace)                         //
-// Project Name:   CV32E40P                                                   //
-// Language:       SystemVerilog                                              //
-//                                                                            //
 // Description:    Logs the following:                                        //
-//                                                                            //
 //                 - APU register file write address                          //
 //                 - APU register file write data                             //
-//                                                                            //
 // Note:           This code was here from cv32e40p_core.sv in order to       //
 //                 remove the use of global defines in the RTL code.          //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 `ifdef CV32E40P_APU_TRACE

--- a/bhv/cv32e40p_core_log.sv
+++ b/bhv/cv32e40p_core_log.sv
@@ -1,39 +1,28 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2020 Silicon Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// This file, and derivatives thereof are licensed under the
-// Solderpad License, Version 2.0 (the "License").
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
 //
-// Use of this file means you agree to the terms and conditions
-// of the license and are in full compliance with the License.
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// You may obtain a copy of the License at:
-//
-//     https://solderpad.org/licenses/SHL-2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// and hardware implementations thereof distributed under the License
-// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
-//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
-//                                                                            //
-// Design Name:    cv32e40p_core_log.sv (cv32e40p_core simulation log)        //
-// Project Name:   CV32E40P                                                   //
-// Language:       SystemVerilog                                              //
-//                                                                            //
 // Description:    Logs the following:                                        //
-//                                                                            //
 //                 - top level parameter settings                             //
 //                 - illegal instructions                                     //
-//                                                                            //
 // Note:           This code was here from cv32e40p_core.sv and               //
 //                 cv32e40p_controller.sv in order to remove the use of       //
 //                 global defines in the RTL code.                            //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_core_log #(

--- a/bhv/cv32e40p_instr_trace.svh
+++ b/bhv/cv32e40p_instr_trace.svh
@@ -1,23 +1,24 @@
-// Copyright (c) 2020 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-// Tracer data structures and functions
-//
-// Contributors: Steve Richmond, Silicon Labs <steve.richmond@silabs.com>
-//               Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>
+/////////////////////////////////////////////////////////////////////////////
+// Contributors: Steve Richmond, Silicon Labs <steve.richmond@silabs.com>  //
+//               Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>  //
+// Description:  Tracer data structures and functions                      //
+/////////////////////////////////////////////////////////////////////////////
 
 typedef struct {
   logic [5:0] addr;

--- a/bhv/cv32e40p_rvfi.sv
+++ b/bhv/cv32e40p_rvfi.sv
@@ -1,24 +1,25 @@
-// Copyright (c) 2020 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-// CV32E40P RVFI interface
-//
-// Contributors: Davide Schiavone, OpenHW Group <davide@openhwgroup.org>
-//               Halfdan Bechmann, Silicon Labs <halfdan.bechmann@silabs.com>
-//               Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>
+/////////////////////////////////////////////////////////////////////////////////
+// Contributors: Davide Schiavone, OpenHW Group <davide@openhwgroup.org>       //
+//               Halfdan Bechmann, Silicon Labs <halfdan.bechmann@silabs.com>  //
+//               Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>      //
+// Description:  CV32E40P RVFI interface                                       //
+/////////////////////////////////////////////////////////////////////////////////
 
 `include "cv32e40p_rvfi_pkg.sv"
 

--- a/bhv/cv32e40p_rvfi_trace.sv
+++ b/bhv/cv32e40p_rvfi_trace.sv
@@ -1,23 +1,24 @@
-// Copyright (c) 2020 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-// CV32E40P RVFI interface
-//
-// Contributors: Halfdan Bechmann, Silicon Labs <halfdan.bechmann@silabs.com>
-//               Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>
+/////////////////////////////////////////////////////////////////////////////////
+// Contributors: Halfdan Bechmann, Silicon Labs <halfdan.bechmann@silabs.com>  //
+//               Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>      //
+// Description:  CV32E40P RVFI interface tracer                                //
+/////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_rvfi_trace
   import cv32e40p_pkg::*;

--- a/bhv/cv32e40p_sim_clock_gate.sv
+++ b/bhv/cv32e40p_sim_clock_gate.sv
@@ -1,12 +1,19 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2017 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // !!! cv32e40p_sim_clock_gate file is meant for simulation only !!!
 // !!! It must not be used for ASIC synthesis                    !!!

--- a/bhv/cv32e40p_tb_wrapper.sv
+++ b/bhv/cv32e40p_tb_wrapper.sv
@@ -1,23 +1,24 @@
-// Copyright (c) 2020 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-// Wrapper for a cv32e40p, containing cv32e40p_top, and rvfi_tracer
-//
-// Contributors: Davide Schiavone, OpenHW Group <davide@openhwgroup.org>
-//               Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>
+/////////////////////////////////////////////////////////////////////////////////////
+// Contributors: Davide Schiavone, OpenHW Group <davide@openhwgroup.org>           //
+//               Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>          //
+// Description:  Wrapper for a cv32e40p, containing cv32e40p_top, and rvfi_tracer  //
+/////////////////////////////////////////////////////////////////////////////////////
 
 `ifdef CV32E40P_ASSERT_ON
 `include "cv32e40p_prefetch_controller_sva.sv"

--- a/bhv/cv32e40p_tracer.sv
+++ b/bhv/cv32e40p_tracer.sv
@@ -1,24 +1,25 @@
-// Copyright (c) 2020 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-// Traces the executed instructions
-//
-// Contributors: Andreas Traber, ETHZ <atraber@iis.ee.ethz.ch>
-//               Davide Schiavone, OpenHW Group <davide@openhwgroup.org>
-//               Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>
+///////////////////////////////////////////////////////////////////////////////////////////
+// Contributors: Andreas Traber, ETHZ <atraber@iis.ee.ethz.ch>                           //
+//               Davide Schiavone, OpenHW Group <davide@openhwgroup.org>                 //
+//               Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>                //
+// Description:  Traces the executed instructions                                        //
+///////////////////////////////////////////////////////////////////////////////////////////
 
 `ifdef CV32E40P_TRACE_EXECUTION
 

--- a/bhv/include/cv32e40p_rvfi_pkg.sv
+++ b/bhv/include/cv32e40p_rvfi_pkg.sv
@@ -1,18 +1,18 @@
-// Copyright (c) 2020 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
 // Includes to print info about the RVFI output
 //

--- a/bhv/include/cv32e40p_tracer_pkg.sv
+++ b/bhv/include/cv32e40p_tracer_pkg.sv
@@ -1,18 +1,18 @@
-// Copyright (c) 2020 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
 // Tracer package
 //

--- a/bhv/insn_trace.sv
+++ b/bhv/insn_trace.sv
@@ -1,5 +1,18 @@
-// Copyright 2022 Dolphin Design
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
   `define DEFINE_CSR(CSR_NAME) \
     logic ``CSR_NAME``_we; \

--- a/bhv/pipe_freeze_trace.sv
+++ b/bhv/pipe_freeze_trace.sv
@@ -1,27 +1,25 @@
-// Copyright (c) 2023 OpenHW Group
+// Copyright 2024 OpenHW Group and Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
 // You may obtain a copy of the License at
 //
-// https://solderpad.org/licenses/
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-// CV32E40P
-//
-// Contributors: Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>
+///////////////////////////////////////////////////////////////////////////////////////////
+// Contributors: Yoann Pruvost, Dolphin Design <yoann.pruvost@dolphin.fr>                //
+// This struct is used to store all information comming from the core at every posedge.  //
+// The information will then be processed.                                               //
+///////////////////////////////////////////////////////////////////////////////////////////
 
-/*
-   * This struct is used to store all information comming from the core at every posedge
-   * The information will then be processed
-   */
 typedef struct {
   logic is_decoding;
   logic is_illegal;

--- a/rtl/cv32e40p_aligner.sv
+++ b/rtl/cv32e40p_aligner.sv
@@ -1,24 +1,25 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Pasquale Davide Schiavone - pschiavo@iis.ee.ethz.ch        //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Igor Loi - igor.loi@greenwaves-technologies.com            //
-//                                                                            //
-// Design Name:    Instrctuon Aligner                                         //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Pasquale Davide Schiavone - pschiavo@iis.ee.ethz.ch  //
+// Additional contributions by: Igor Loi - igor.loi@greenwaves-technologies.com      //
+// Description:                 Instruction Aligner                                  //
+///////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_aligner (
     input logic clk,

--- a/rtl/cv32e40p_alu.sv
+++ b/rtl/cv32e40p_alu.sv
@@ -1,29 +1,28 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Matthias Baer - baermatt@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Igor Loi - igor.loi@unibo.it                               //
-//                 Andreas Traber - atraber@student.ethz.ch                   //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    ALU                                                        //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Arithmetic logic unit of the pipelined processor           //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Matthias Baer - baermatt@student.ethz.ch          //
+// Additional contributions by: Igor Loi - igor.loi@unibo.it                      //
+//                              Andreas Traber - atraber@student.ethz.ch          //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch        //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch        //
+// Description:                 Arithmetic logic unit of the pipelined processor  //
+////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_alu
   import cv32e40p_pkg::*;

--- a/rtl/cv32e40p_alu_div.sv
+++ b/rtl/cv32e40p_alu_div.sv
@@ -1,26 +1,24 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 ///////////////////////////////////////////////////////////////////////////////
-// File       : Simple Serial Divider
-// Ver        : 1.0
-// Date       : 15.03.2016
-///////////////////////////////////////////////////////////////////////////////
-//
-// Description: this is a simple serial divider for signed integers (int32).
-//
-///////////////////////////////////////////////////////////////////////////////
-//
-// Authors    : Michael Schaffner (schaffner@iis.ee.ethz.ch)
-//              Andreas Traber    (atraber@iis.ee.ethz.ch)
-//
+// Authors:     Michael Schaffner (schaffner@iis.ee.ethz.ch)                 //
+//              Andreas Traber    (atraber@iis.ee.ethz.ch)                   //
+// Description: This is a simple serial divider for signed integers (int32). //
 ///////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_alu_div #(

--- a/rtl/cv32e40p_apu_disp.sv
+++ b/rtl/cv32e40p_apu_disp.sv
@@ -1,26 +1,25 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Lukas Mueller - lukasmue@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    Simple APU dispatcher                                      //
-// Project Name:   PULP                                                       //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Dispatcher for sending instructions to the Marx            //
-//                 interconnect.                                              //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Lukas Mueller - lukasmue@student.ethz.ch                      //
+// Additional contributions by: Michael Gautschi - gautschi@iis.ee.ethz.ch                    //
+// Description:                 Dispatcher for sending FPU instructions to APU interface.     //
+////////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_apu_disp (
     input logic clk_i,

--- a/rtl/cv32e40p_compressed_decoder.sv
+++ b/rtl/cv32e40p_compressed_decoder.sv
@@ -1,27 +1,26 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Sven Stucki - svstucki@student.ethz.ch                     //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    Compressed instruction decoder                             //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Decodes RISC-V compressed instructions into their RV32     //
-//                 equivalent. This module is fully combinatorial.            //
-//                 Float extensions added                                     //
-//                                                                            //
+// Engineer:                    Sven Stucki - svstucki@student.ethz.ch        //
+// Additional contributions by: Michael Gautschi - gautschi@iis.ee.ethz.ch    //
+// Description:                 Decodes RISC-V compressed instructions into   //
+//                              their RV32IF equivalent.                      //
+//                              This module is fully combinatorial.           //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_compressed_decoder #(

--- a/rtl/cv32e40p_controller.sv
+++ b/rtl/cv32e40p_controller.sv
@@ -1,32 +1,31 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Matthias Baer - baermatt@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Igor Loi - igor.loi@unibo.it                               //
-//                 Andreas Traber - atraber@student.ethz.ch                   //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                 Robert Balas - balasr@iis.ee.ethz.ch                       //
-//                 Andrea Bettati - andrea.bettati@studenti.unipr.it          //
-//                                                                            //
-// Design Name:    Main controller                                            //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Main CPU controller of the processor                       //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Matthias Baer - baermatt@student.ethz.ch           //
+// Additional contributions by: Igor Loi - igor.loi@unibo.it                       //
+//                              Andreas Traber - atraber@student.ethz.ch           //
+//                              Sven Stucki - svstucki@student.ethz.ch             //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch         //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch         //
+//                              Robert Balas - balasr@iis.ee.ethz.ch               //
+//                              Andrea Bettati - andrea.bettati@studenti.unipr.it  //
+// Description:                 Main CPU controller of the processor               //
+/////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_controller import cv32e40p_pkg::*;
 #(

--- a/rtl/cv32e40p_core.sv
+++ b/rtl/cv32e40p_core.sv
@@ -1,32 +1,30 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Matthias Baer - baermatt@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Igor Loi - igor.loi@unibo.it                               //
-//                 Andreas Traber - atraber@student.ethz.ch                   //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    Top level module                                           //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Top level module of the RISC-V core.                       //
-//                 added APU, FPU parameter to include the APU_dispatcher     //
-//                 and the FPU                                                //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Matthias Baer - baermatt@student.ethz.ch                 //
+// Additional contributions by: Igor Loi - igor.loi@unibo.it                             //
+//                              Andreas Traber - atraber@student.ethz.ch                 //
+//                              Sven Stucki - svstucki@student.ethz.ch                   //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch               //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch               //
+//                              Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr> //
+// Description:                 Core level module of CV32E40P                            //
+///////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_core
   import cv32e40p_apu_core_pkg::*;

--- a/rtl/cv32e40p_cs_registers.sv
+++ b/rtl/cv32e40p_cs_registers.sv
@@ -1,31 +1,29 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Sven Stucki - svstucki@student.ethz.ch                     //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Andreas Traber - atraber@iis.ee.ethz.ch                    //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                 Andrea Bettati - andrea.bettati@studenti.unipr.it          //
-//                                                                            //
-// Design Name:    Control and Status Registers                               //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Control and Status Registers (CSRs) loosely following the  //
-//                 RiscV draft priviledged instruction set spec (v1.9)        //
-//                 Added Floating point support                               //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Sven Stucki - svstucki@student.ethz.ch                    //
+// Additional contributions by: Andreas Traber - atraber@iis.ee.ethz.ch                   //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch                //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch                //
+//                              Andrea Bettati - andrea.bettati@studenti.unipr.it         //
+//                              Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>  //
+// Design Name:                 Control and Status Registers                              //
+////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_cs_registers
   import cv32e40p_pkg::*;

--- a/rtl/cv32e40p_decoder.sv
+++ b/rtl/cv32e40p_decoder.sv
@@ -1,29 +1,29 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer        Andreas Traber - atraber@iis.ee.ethz.ch                    //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Matthias Baer - baermatt@student.ethz.ch                   //
-//                 Igor Loi - igor.loi@unibo.it                               //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    Decoder                                                    //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Decoder                                                    //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer                     Andreas Traber - atraber@iis.ee.ethz.ch                   //
+// Additional contributions by: Matthias Baer - baermatt@student.ethz.ch                  //
+//                              Igor Loi - igor.loi@unibo.it                              //
+//                              Sven Stucki - svstucki@student.ethz.ch                    //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch                //
+//                              Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>  //
+// Description:                 Central Instructions Decoder                              //
+////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_decoder
   import cv32e40p_pkg::*;

--- a/rtl/cv32e40p_ex_stage.sv
+++ b/rtl/cv32e40p_ex_stage.sv
@@ -1,33 +1,33 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Renzo Andri - andrire@student.ethz.ch                      //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Igor Loi - igor.loi@unibo.it                               //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                 Andreas Traber - atraber@iis.ee.ethz.ch                    //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    Execute stage                                              //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Execution stage: Hosts ALU and MAC unit                    //
-//                 ALU: computes additions/subtractions/comparisons           //
-//                 MULT: computes normal multiplications                      //
-//                 APU_DISP: offloads instructions to the shared unit.        //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Renzo Andri - andrire@student.ethz.ch                       //
+// Additional contributions by: Igor Loi - igor.loi@unibo.it                                //
+//                              Sven Stucki - svstucki@student.ethz.ch                      //
+//                              Andreas Traber - atraber@iis.ee.ethz.ch                     //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch                  //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch                  //
+//                              Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>    //
+// Description:                 Execution stage: Hosts ALU and MAC unit                     //
+//                              ALU: computes additions/subtractions/comparisons/divisions  //
+//                              MULT: computes normal multiplications                       //
+//                              APU_DISP: offloads instructions to CVFPU.                   //
+//////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_ex_stage
   import cv32e40p_pkg::*;

--- a/rtl/cv32e40p_ff_one.sv
+++ b/rtl/cv32e40p_ff_one.sv
@@ -1,26 +1,25 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Andreas Traber - atraber@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    cv32e40p_ff_one                                               //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Find First One                                             //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Andreas Traber - atraber@student.ethz.ch   //
+// Additional contributions by: Davide Schiavone - pschiavo@iis.ee.ethz.ch //
+// Description:                 Find First One                             //
+/////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_ff_one #(
     parameter LEN = 32

--- a/rtl/cv32e40p_fifo.sv
+++ b/rtl/cv32e40p_fifo.sv
@@ -1,16 +1,24 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License. You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
-
-// Copy of fifo_v3 from https://github.com/pulp-platform/common_cells b2a4b2d3decdfc152ad9b4564a48ed3b2649fd6c
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer: Florian Zaruba <zarubaf@iis.ee.ethz.ch>                                                           //
+// Copy of fifo_v3 from https://github.com/pulp-platform/common_cells b2a4b2d3decdfc152ad9b4564a48ed3b2649fd6c //
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_fifo #(
     parameter bit FALL_THROUGH = 1'b0,  // fifo is in fall-through mode

--- a/rtl/cv32e40p_fp_wrapper.sv
+++ b/rtl/cv32e40p_fp_wrapper.sv
@@ -1,15 +1,24 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// Wrapper for a fpnew
-// Contributor: Davide Schiavone <davide@openhwgroup.org>
+/////////////////////////////////////////////////////////////
+// Engineer:    Davide Schiavone <davide@openhwgroup.org>  //
+// Description: Wrapper of CVFPU                           //
+/////////////////////////////////////////////////////////////
 
 module cv32e40p_fp_wrapper
   import cv32e40p_apu_core_pkg::*;

--- a/rtl/cv32e40p_hwloop_regs.sv
+++ b/rtl/cv32e40p_hwloop_regs.sv
@@ -1,26 +1,28 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    hwloop regs                                                //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Hardware loop registers                                    //
-//                 a) store start/end address of N=4 hardware loops           //
-//                 b) store init value of counter for each hardware loop      //
-//                 c) decrement counter if hwloop taken                       //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Michael Gautschi - gautschi@iis.ee.ethz.ch                //
+// Additional contributions by: Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>  //
+// Description:                 Hardware loop registers                                   //
+//                              a) store start/end address of N=4 hardware loops          //
+//                              b) store init value of counter for each hardware loop     //
+//                              c) decrement counter if hwloop taken                      //
+////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_hwloop_regs #(
     parameter N_REGS     = 2,

--- a/rtl/cv32e40p_id_stage.sv
+++ b/rtl/cv32e40p_id_stage.sv
@@ -1,31 +1,30 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Renzo Andri - andrire@student.ethz.ch                      //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Igor Loi - igor.loi@unibo.it                               //
-//                 Andreas Traber - atraber@student.ethz.ch                   //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    Instruction Decode Stage                                   //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Decode stage of the core. It decodes the instructions      //
-//                 and hosts the register file.                               //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Renzo Andri - andrire@student.ethz.ch                    //
+// Additional contributions by: Igor Loi - igor.loi@unibo.it                             //
+//                              Andreas Traber - atraber@student.ethz.ch                 //
+//                              Sven Stucki - svstucki@student.ethz.ch                   //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch               //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch               //
+// Description:                 Decode stage of the core.                                //
+//                              It decodes the instructions and hosts the register file. //
+///////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_id_stage
   import cv32e40p_pkg::*;

--- a/rtl/cv32e40p_if_stage.sv
+++ b/rtl/cv32e40p_if_stage.sv
@@ -1,29 +1,28 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Renzo Andri - andrire@student.ethz.ch                      //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Igor Loi - igor.loi@unibo.it                               //
-//                 Andreas Traber - atraber@student.ethz.ch                   //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                                                                            //
-// Design Name:    Instruction Fetch Stage                                    //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Instruction fetch unit: Selection of the next PC, and      //
-//                 buffering (sampling) of the read instruction               //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Renzo Andri - andrire@student.ethz.ch                           //
+// Additional contributions by: Igor Loi - igor.loi@unibo.it                                    //
+//                              Andreas Traber - atraber@student.ethz.ch                        //
+//                              Sven Stucki - svstucki@student.ethz.ch                          //
+// Description:                 Instruction fetch unit                                          //
+//                              Selection of the next PC and buffering of the read instruction. //
+//////////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_if_stage #(
     parameter COREV_PULP = 0, // PULP ISA Extension (including PULP specific CSRs and hardware loop, excluding cv.elw)

--- a/rtl/cv32e40p_int_controller.sv
+++ b/rtl/cv32e40p_int_controller.sv
@@ -1,24 +1,23 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Additional contributions by:                                               //
-//                                                                            //
-// Design Name:    Interrupt Controller                                       //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Interrupt Controller of the pipelined processor            //
-//                                                                            //
+// Description:    Interrupt Controller of CV32E40P processor                 //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_int_controller

--- a/rtl/cv32e40p_load_store_unit.sv
+++ b/rtl/cv32e40p_load_store_unit.sv
@@ -1,27 +1,26 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Igor Loi - igor.loi@unibo.it                               //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Andreas Traber - atraber@iis.ee.ethz.ch                    //
-//                                                                            //
-// Design Name:    Load Store Unit                                            //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Load Store Unit, used to eliminate multiple access during  //
-//                 processor stalls, and to align bytes and halfwords         //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Igor Loi - igor.loi@unibo.it                               //
+// Additional contributions by: Andreas Traber - atraber@iis.ee.ethz.ch                    //
+// Description:                 Load Store Unit, used to eliminate multiple access during  //
+//                              processor stalls, and to align bytes and halfwords.        //
+/////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_load_store_unit #(
     parameter PULP_OBI = 0  // Legacy PULP OBI behavior

--- a/rtl/cv32e40p_mult.sv
+++ b/rtl/cv32e40p_mult.sv
@@ -1,26 +1,25 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Matthias Baer - baermatt@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Andreas Traber - atraber@student.ethz.ch                   //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    Subword multiplier and MAC                                 //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Advanced MAC unit for PULP.                                //
-//                                                                            //
+// Engineer:                    Matthias Baer - baermatt@student.ethz.ch      //
+// Additional contributions by: Andreas Traber - atraber@student.ethz.ch      //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch    //
+// Description:                 Subword multiplier and MAC                    //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_mult

--- a/rtl/cv32e40p_obi_interface.sv
+++ b/rtl/cv32e40p_obi_interface.sv
@@ -1,38 +1,29 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2020 Silicon Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// This file, and derivatives thereof are licensed under the
-// Solderpad License, Version 2.0 (the "License").
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
 //
-// Use of this file means you agree to the terms and conditions
-// of the license and are in full compliance with the License.
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// You may obtain a copy of the License at:
-//
-//     https://solderpad.org/licenses/SHL-2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// and hardware implementations thereof distributed under the License
-// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
-//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
-//                                                                            //
 // Design Name:    OBI (Open Bus Interface)                                   //
-// Project Name:   CV32E40P                                                   //
-// Language:       SystemVerilog                                              //
-//                                                                            //
 // Description:    Open Bus Interface adapter. Translates transaction request //
 //                 on the trans_* interface into an OBI A channel transfer.   //
 //                 The OBI R channel transfer translated (i.e. passed on) as  //
 //                 a transaction response on the resp_* interface.            //
-//                                                                            //
 //                 This adapter does not limit the number of outstanding      //
 //                 OBI transactions in any way.                               //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_obi_interface #(

--- a/rtl/cv32e40p_popcnt.sv
+++ b/rtl/cv32e40p_popcnt.sv
@@ -1,25 +1,24 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Andreas Traber - atraber@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    cv32e40p_popcnt                                               //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Count the number of '1's in a word                         //
-//                                                                            //
+// Engineer:                    Andreas Traber - atraber@student.ethz.ch      //
+// Additional contributions by: Davide Schiavone - pschiavo@iis.ee.ethz.ch    //
+// Description:                 Count the number of '1's in a word            //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_popcnt (

--- a/rtl/cv32e40p_prefetch_buffer.sv
+++ b/rtl/cv32e40p_prefetch_buffer.sv
@@ -1,23 +1,25 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Andreas Traber - atraber@iis.ee.ethz.ch                    //
-//                                                                            //
-// Design Name:    Prefetcher Buffer for 32 bit memory interface              //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Prefetch Buffer that caches instructions. This cuts overly //
-//                 long critical paths to the instruction cache               //
-//                                                                            //
+// Description:    Prefetcher Buffer for 32 bit memory interface              //
+//                 Prefetch Buffer that caches instructions. This cuts overly //
+//                 long critical paths to the instruction cache.              //
 ////////////////////////////////////////////////////////////////////////////////
 
 // input port: send address one cycle before the data

--- a/rtl/cv32e40p_prefetch_controller.sv
+++ b/rtl/cv32e40p_prefetch_controller.sv
@@ -1,30 +1,23 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2020 Silicon Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// This file, and derivatives thereof are licensed under the
-// Solderpad License, Version 2.0 (the "License").
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
 //
-// Use of this file means you agree to the terms and conditions
-// of the license and are in full compliance with the License.
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// You may obtain a copy of the License at:
-//
-//     https://solderpad.org/licenses/SHL-2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// and hardware implementations thereof distributed under the License
-// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
-//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
-//                                                                            //
 // Design Name:    Prefetcher Controller                                      //
-// Project Name:   CV32E40P                                                   //
-// Language:       SystemVerilog                                              //
-//                                                                            //
 // Description:    Prefetch Controller which receives control flow            //
 //                 information (req_i, branch_*) from the Fetch stage         //
 //                 and based on that performs transactions requests to the    //
@@ -34,7 +27,6 @@
 //                 only performed if it can be guaranteed that the fetch FIFO //
 //                 will not overflow (resulting in a maximum of DEPTH         //
 //                 outstanding transactions.                                  //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_prefetch_controller #(

--- a/rtl/cv32e40p_register_file_ff.sv
+++ b/rtl/cv32e40p_register_file_ff.sv
@@ -1,31 +1,30 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Francesco Conti - f.conti@unibo.it                         //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    RISC-V register file                                       //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Register file with 31x 32 bit wide registers. Register 0   //
-//                 is fixed to 0. This register file is based on flip-flops.  //
-//                 Also supports the fp-register file now if FPU=1            //
-//                 If ZFINX is 1, floating point operations take values       //
-//                 from the X register file                                   //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Francesco Conti - f.conti@unibo.it                         //
+// Additional contributions by: Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
+// Description:                 Register file with 31x 32 bit wide registers. Register 0   //
+//                              is fixed to 0. This register file is based on flip-flops.  //
+//                              Also supports the fp-register file if FPU=1 and ZFINX=0.   //
+//                              If ZFINX is 1, floating point operations take values       //
+//                              from the X register file.                                  //
+/////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_register_file #(
     parameter ADDR_WIDTH = 5,

--- a/rtl/cv32e40p_register_file_latch.sv
+++ b/rtl/cv32e40p_register_file_latch.sv
@@ -1,33 +1,33 @@
+// Copyright 2024 OpenHW Group
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Antonio Pullini - pullinia@iis.ee.ethz.ch                  //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                 Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    RISC-V register file                                       //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Register file with 31x 32 bit wide registers. Register 0   //
-//                 is fixed to 0. This register file is based on latches and  //
-//                 is thus smaller than the flip-flop based register file.    //
-//                 Also supports the fp-register file now if FPU=1            //
-//                 If ZFINX is 1, floating point operations take values       //
-//                 from the X register file                                   //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Antonio Pullini - pullinia@iis.ee.ethz.ch                  //
+// Additional contributions by: Sven Stucki - svstucki@student.ethz.ch                     //
+//                              Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
+//                              Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
+// Design Name:                 RISC-V register file                                       //
+// Description:                 Register file with 31x 32 bit wide registers. Register 0   //
+//                              is fixed to 0. This register file is based on latches and  //
+//                              is thus smaller than the flip-flop based register file.    //
+//                              Also supports the fp-register file now if FPU=1            //
+//                              If ZFINX is 1, floating point operations take values       //
+//                              from the X register file                                   //
+/////////////////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_register_file #(
     parameter ADDR_WIDTH = 5,

--- a/rtl/cv32e40p_sleep_unit.sv
+++ b/rtl/cv32e40p_sleep_unit.sv
@@ -1,48 +1,35 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2020 Silicon Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// This file, and derivatives thereof are licensed under the
-// Solderpad License, Version 2.0 (the "License").
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
 //
-// Use of this file means you agree to the terms and conditions
-// of the license and are in full compliance with the License.
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// You may obtain a copy of the License at:
-//
-//     https://solderpad.org/licenses/SHL-2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// and hardware implementations thereof distributed under the License
-// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
-//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
-//                                                                            //
 // Design Name:    Sleep Unit                                                 //
-// Project Name:   CV32E40P                                                   //
-// Language:       SystemVerilog                                              //
-//                                                                            //
 // Description:    Sleep unit containing the instantiated clock gate which    //
 //                 provides the gated clock (clk_gated_o) for the rest        //
 //                 of the design.                                             //
-//                                                                            //
 //                 The clock is gated for the following scenarios:            //
-//                                                                            //
 //                 - While waiting for fetch to become enabled                //
 //                 - While blocked on a WFI (COREV_CLUSTER = 0)               //
 //                 - While clock_en_i = 0 during a cv.elw (COREV_CLUSTER = 1) //
-//                                                                            //
 //                 Sleep is signaled via core_sleep_o when:                   //
-//                                                                            //
 //                 - During a cv.elw (except in debug (i.e. pending debug     //
 //                   request, debug mode, single stepping, trigger match)     //
 //                 - During a WFI (except in debug)                           //
-//                                                                            //
 // Requirements:   If COREV_CLUSTER = 1 the environment must guarantee:       //
-//                                                                            //
 //                 - If core_sleep_o    == 1'b0, then pulp_clock_en_i == 1'b1 //
 //                 - If pulp_clock_en_i == 1'b0, then irq_i == 'b0            //
 //                 - If pulp_clock_en_i == 1'b0, then debug_req_i == 1'b0     //
@@ -50,7 +37,6 @@
 //                 - If pulp_clock_en_i == 1'b0, then instr_gnt_i == 1'b0     //
 //                 - If pulp_clock_en_i == 1'b0, then data_rvalid_i == 1'b0   //
 //                 - If pulp_clock_en_i == 1'b0, then data_gnt_i == 1'b1      //
-//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_sleep_unit #(

--- a/rtl/cv32e40p_top.sv
+++ b/rtl/cv32e40p_top.sv
@@ -1,15 +1,26 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// Top file instantiating a CV32E40P core and an optional FPU
-// Contributor: Davide Schiavone <davide@openhwgroup.org>
+/////////////////////////////////////////////////////////////////////////////
+// Contributors: Davide Schiavone, OpenHW Group <davide@openhwgroup.org>   //
+//               Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>  //
+// Description:  Top level module of CV32E40P instantiating the Core and   //
+//               an optional CVFPU with its clock gating cell.             //
+/////////////////////////////////////////////////////////////////////////////
 
 module cv32e40p_top #(
     parameter COREV_PULP = 0, // PULP ISA Extension (incl. custom CSRs and hardware loop, excl. cv.elw)

--- a/rtl/include/cv32e40p_apu_core_pkg.sv
+++ b/rtl/include/cv32e40p_apu_core_pkg.sv
@@ -1,22 +1,23 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Michael Gautschi - gautschi@iis.ee.ethz.ch                 //
-//                                                                            //
-// Design Name:    APU-core package                                           //
-// Project Name:   RISC-V                                                     //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    core package of RISC-V core for shared APU                 //
-//                                                                            //
+// Description:    Core package for APU/CVFPU interface                       //
 ////////////////////////////////////////////////////////////////////////////////
 
 package cv32e40p_apu_core_pkg;

--- a/rtl/include/cv32e40p_fpu_pkg.sv
+++ b/rtl/include/cv32e40p_fpu_pkg.sv
@@ -1,38 +1,24 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2020 Silicon Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// This file, and derivatives thereof are licensed under the
-// Solderpad License, Version 2.0 (the "License").
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
 //
-// Use of this file means you agree to the terms and conditions
-// of the license and are in full compliance with the License.
+// https://solderpad.org/licenses/SHL-2.1/
 //
-// You may obtain a copy of the License at:
-//
-//     https://solderpad.org/licenses/SHL-2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// and hardware implementations thereof distributed under the License
-// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
-//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
 // Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
-//                                                                            //
 // Design Name:    FPU package                                                //
-// Project Name:   CV32E40P                                                   //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    FPU types needed for FPNEW integration. A local copy was   //
-//                 made to avoid a github dependency to non-OpenHW modules.   //
-//                                                                            //
-//                 If the FPU is used (FPU=1), then the types and parameters  //
-//                 in this package must match with the corresponding types    //
-//                 and parameters in the src/fpnew_pkg.sv package of          //
-//                 https://github.com/pulp-platform/fpnew/                    //
-//                                                                            //
+// Description:    FPU types needed for CVFPU integration.                    //
 ////////////////////////////////////////////////////////////////////////////////
 
 package cv32e40p_fpu_pkg;

--- a/rtl/include/cv32e40p_pkg.sv
+++ b/rtl/include/cv32e40p_pkg.sv
@@ -1,27 +1,25 @@
+// Copyright 2024 OpenHW Group and Dolphin Design
 // Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License.  You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License");
+// you may not use this file except in compliance with the License, or,
+// at your option, the Apache License version 2.0.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Matthias Baer - baermatt@student.ethz.ch                   //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Sven Stucki - svstucki@student.ethz.ch                     //
-//                                                                            //
-//                                                                            //
-// Design Name:    RISC-V processor core                                      //
-// Project Name:   RI5CY                                                      //
-// Language:       SystemVerilog                                              //
-//                                                                            //
-// Description:    Defines for various constants used by the processor core.  //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////
+// Engineer:                    Matthias Baer - baermatt@student.ethz.ch                  //
+// Additional contributions by: Sven Stucki - svstucki@student.ethz.ch                    //
+//                              Pascal Gouedo, Dolphin Design <pascal.gouedo@dolphin.fr>  //
+////////////////////////////////////////////////////////////////////////////////////////////
 
 package cv32e40p_pkg;
 


### PR DESCRIPTION
Used latest Solderpad Hardware License v2.1 defined in Appendix [here](http://solderpad.org/licenses/SHL-2.1/).