### PR TITLE
Update pointer to v1.0.0 coverage reports

### DIFF
--- a/docs/source/verification.rst
+++ b/docs/source/verification.rst
@@ -30,7 +30,7 @@ v1.0.0 verification
 
 In early 2021 the CV32E40P achieved Functional RTL Freeze (released with cv32e40p_v1.0.0 version), meaning that is has been fully verified as per its
 `Verification Plan <https://github.com/openhwgroup/core-v-verif/tree/cv32e40p/dev/cv32e40p/docs/VerifPlans/README.md>`_.
-Final functional, code and test coverage reports can be found `here <https://github.com/openhwgroup/core-v-verif/blob/master/docs/Reports/cv32e40p/index.html>`_.
+Final functional, code and test coverage reports can be found `here <https://github.com/openhwgroup/programs/tree/master/Project-Descriptions-and-Plans/CV32E40Pv1/Milestone-data/Reports>`_.
 
 The unofficial start date for the CV32E40P verification effort is 2020-02-27,
 which is the date the core-v-verif environment "went live".  Between then and


### PR DESCRIPTION
A minor update to the README for the [CV32E40P v1 Milestone data](https://github.com/openhwgroup/programs/tree/master/Project-Descriptions-and-Plans/CV32E40Pv1/Milestone-data) was pushed into the Programs repo and this PR points to that directory.