### PR TITLE
Update Ubuntu runner version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
   format_verilog:
     name: Format Verilog Sources
     # This job runs on Linux (fixed ubuntu version)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
Update in reaction to message from GitHub:
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.