### PR TITLE
rtl: add missing fpu divsqrt file to manifest (Fixes #1049)

### DIFF
--- a/cv32e40p_fpu_manifest.flist
+++ b/cv32e40p_fpu_manifest.flist
@@ -74,6 +74,7 @@ ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/vendor/opene906/E906_RTL_FACTORY/ge
 ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/vendor/opene906/E906_RTL_FACTORY/gen_rtl/fpu/rtl/pa_fpu_frbus.v
 ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/vendor/opene906/E906_RTL_FACTORY/gen_rtl/fpu/rtl/pa_fpu_src_type.v
 ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_divsqrt_th_32.sv
+${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_divsqrt_multi.sv
 ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_classifier.sv
 ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_rounding.sv
 ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_cast_multi.sv


### PR DESCRIPTION
Description: This PR addresses Issue #1049 where the floating-point division/square-root unit was failing to compile or stall during simulation because fpnew_divsqrt_multi.sv was missing from the manifest list.

Changes:

    Added ${DESIGN_RTL_DIR}/vendor/pulp_platform_fpnew/src/fpnew_divsqrt_multi.sv to cv32e40p_fpu_manifest.flist.

    Organized the entry to sit alongside related divsqrt source files for better maintainability.

Signed-off-by: Divyam Shankhdhar