### PR TITLE
Fix FPU simulation issue in Vivado simulator

### DIFF
--- a/rtl/vendor/pulp_platform_fpnew/src/fpnew_pkg.sv
+++ b/rtl/vendor/pulp_platform_fpnew/src/fpnew_pkg.sv
@@ -56,6 +56,24 @@ package fpnew_pkg;
     // add new formats here
   };
 
+  localparam int unsigned FP_EXP [0:NUM_FP_FORMATS-1]  = '{
+    8,  // IEEE binary32 (single)
+    11, // IEEE binary64 (double)
+    5,  // IEEE binary16 (half)
+    5,  // custom binary8
+    8   // custom binary16alt
+    // add new formats here
+  };
+
+  localparam int unsigned FP_MANTISSA [0:NUM_FP_FORMATS-1]  = '{
+    23, // IEEE binary32 (single)
+    52, // IEEE binary64 (double)
+    10, // IEEE binary16 (half)
+    2,  // custom binary8
+    7   // custom binary16alt
+    // add new formats here
+  };
+
   typedef logic [0:NUM_FP_FORMATS-1]       fmt_logic_t;    // Logic indexed by FP format (for masks)
   typedef logic [0:NUM_FP_FORMATS-1][31:0] fmt_unsigned_t; // Unsigned indexed by FP format
 
@@ -302,7 +320,7 @@ package fpnew_pkg;
   // -------------------------------------------
   // Returns the width of a FP format
   function automatic int unsigned fp_width(fp_format_e fmt);
-    return FP_ENCODINGS[fmt].exp_bits + FP_ENCODINGS[fmt].man_bits + 1;
+    return FP_EXP[fmt] + FP_MANTISSA[fmt] + 1;
   endfunction
 
   // Returns the widest FP format present
@@ -325,17 +343,17 @@ package fpnew_pkg;
 
   // Returns the number of expoent bits for a format
   function automatic int unsigned exp_bits(fp_format_e fmt);
-    return FP_ENCODINGS[fmt].exp_bits;
+    return FP_EXP[fmt];
   endfunction
 
   // Returns the number of mantissa bits for a format
   function automatic int unsigned man_bits(fp_format_e fmt);
-    return FP_ENCODINGS[fmt].man_bits;
+    return FP_MANTISSA[fmt];
   endfunction
 
   // Returns the bias value for a given format (as per IEEE 754-2008)
   function automatic int unsigned bias(fp_format_e fmt);
-    return unsigned'(2**(FP_ENCODINGS[fmt].exp_bits-1)-1); // symmetrical bias
+    return unsigned'(2**(FP_EXP[fmt]-1)-1); // symmetrical bias
   endfunction
 
   function automatic fp_encoding_t super_format(fmt_logic_t cfg);


### PR DESCRIPTION
Problem:

When simulating the core with FPU enabled in Vivado, executing floating point instructions produces incorrect results. 

I traced back the problem to rtl/vendor/pulp_platform_fpnew/src/fpnew_pkg.sv, where an access to any field in the FP_ENCODINGS struct returns 7. More precisely, an access to any field always returns the value stored in the FP_ENCODINGS[FP16ALT].man field, which holds 7. The FP_ENCODINGS struct is used to retrieve the exponent and mantissa sizes in different floating point representations. 

I found the problem while I was creating a block design to run the cv32e40p core with FPU on the PYNQ-Z2 FPGA. While testing the FPU using a Verilog testbench and Vivado simulation, I noticed that the floating point values in the waveforms were incorrect. 

Fix:

To fix the problem I split up the FP_ENCODINGS struct into an FP_EXP and an FP_MAN struct, which store the exponent and mantissa sizes of all representations separately. 

I do not know the root cause of the problem, but I tested the fix in Vivado 2024.1 and 2025.2, and in both cases it fixes the issue without affecting other behavior.