### PR TITLE
Revise contributing guidelines and licensing details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,29 @@
 # Contributing
-Contributors are encouraged to be a [member](https://www.openhwgroup.org/membership/) of the
-OpenHW Group.  New members are always welcome.
+Contributors are encouraged, but not required to be a [member](https://openhwfoundation.org/membership/become-a-member/) of the OpenHW Foundation.
+New contributions are always welcome.
+Start by having a look at the **README**, and review open [Issues](https://github.com/openhwgroup/cv32e40p/issues) with a "Good First Issue" label.
+Please note that the CV32E40P is stable and well verified and in general we will not accept a PR that is
+[not backward compatible](https://docs.openhwgroup.org/projects/cv32e40p-user-manual/en/cv32e40p_v1.8.3/core_versions.html#non-backward-compatibility) with earlier releases.
 
-## Getting Started
-The [OpenHW Work Flow](https://github.com/openhwgroup/programs/blob/master/TGs/verification-task-group/documents/presentations/OpenHWGroup_WorkFlow.pdf) document
-is required reading.  You will find information about the implementation and usage of the CORE-V verification environments
-in the [Verification Strategy](https://docs.openhwgroup.org/projects/core-v-verif/en/latest/intro.html).
+## Contributor Agreement
+OpenHW is part of the [Eclipse Foundation](https://www.eclipse.org/) and all contributors must be covered by the terms of the
+[Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php) (for individuals) **or** the
+[Eclipse Member Committer and Contributor Agreement](https://www.eclipse.org/legal/committer_process/EclipseMemberCommitterAgreement.pdf) (for employees of Member companies).
+The ECA/MCCA provides a legal framework for a Contributor's technical contributions to the OpenHW Foundation,
+including provisions for grant of copyright license and a Developer Certificate of Origin on contributions merged into OpenHW Foundation repositories.
+
+## Licensing
+CV32E40P is an open source project, using permissive licensing.
+Our preferred license is the [Solderpad](https://solderpad.org/licenses/) hardware license, and we accept most well known permissive licenses.
+If you are submitting a new file that does not yet have a copyright header please add the following [SPDX](https://spdx.dev/) header:
+```
+// Copyright (c) <year> <organization>
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+```
+In the above header, "organization" should either be your employer, your institution or yourself:
+- If you are being paid to make a contribution on behalf of an employer, then the copyright will be held by your employer.
+- If an educational institution is supporting your contribution (for example, by providing access to computer and/or tools), then the copyright should be assigned to your educational institution.
+- Otherwise, you may assign the copyright to yourself.  You may use your full name or email address as you see fit.
 
 ## Updating Copyright
 The files in this repository are open-source artifacts licensed under the terms of the Solderpad license, see [LICENSE](LICENSE).
@@ -14,7 +32,7 @@ If your contribution uses a newer version of the existing license, you are encou
 
 In the example below, a new copyright and updated license are added to an existing copyright and license:
 ```
-// Copyright 2024 OpenHW Group and <member-company>
+// Copyright (c) <year> <organization>
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 // Copyright 2018 ETH Zurich and University of Bologna.
 // Copyright and related rights are licensed under the Solderpad Hardware


### PR DESCRIPTION
CONTRIBUTING did not include information about the ECA.  While I was fixing that, I made a few additional changes, primarily to update OpenHW links to Eclipse links.  I also took the liberty of highlighting the backward compatibility rules.