### PR TITLE
fix: Replace the blocking assignment in the always_latch block with a non-blocking assignment

### DIFF
--- a/rtl/cv32e40p_register_file_latch.sv
+++ b/rtl/cv32e40p_register_file_latch.sv
@@ -169,7 +169,7 @@ module cv32e40p_register_file #(
   // Integer registers
   always_latch begin : latch_wdata
     // Note: The assignment has to be done inside this process or Modelsim complains about it
-    mem[0] = '0;
+    mem[0] <= '0;
 
     for (k = 1; k < NUM_WORDS; k++) begin : w_WordIter
       if (~rst_n) mem[k] <= '0;


### PR DESCRIPTION
Fix: Replace the blocking assignment in the always_latch block with a non-blocking assignment to avoid mixing blocking and non-blocking assignments in the same procedural block in cv32e40p_register_file_latch.sv.